### PR TITLE
RFE: add support for tty field in LOGIN message

### DIFF
--- a/tests/login_tty/Makefile
+++ b/tests/login_tty/Makefile
@@ -1,0 +1,8 @@
+TARGETS=$(patsubst %.c,%,$(wildcard *.c))
+
+LDLIBS += -lpthread
+
+all: $(TARGETS)
+clean:
+	rm -f $(TARGETS)
+

--- a/tests/login_tty/test
+++ b/tests/login_tty/test
@@ -1,0 +1,68 @@
+#!/usr/bin/perl
+
+use strict;
+
+use Test;
+BEGIN { plan tests => 2 }
+
+use File::Temp qw/ tempdir tempfile /;
+
+###
+# functions
+
+###
+# setup
+
+# reset audit
+system("auditctl -D >& /dev/null");
+
+# create stdout/stderr sinks
+(my $fh_out, my $stdout) = tempfile(TEMPLATE => '/tmp/audit-testsuite-out-XXXX',
+				    UNLINK => 1);
+(my $fh_err, my $stderr) = tempfile(TEMPLATE => '/tmp/audit-testsuite-err-XXXX',
+				    UNLINK => 1);
+(my $fh_tty, my $ttyout) = tempfile(TEMPLATE => '/tmp/audit-testsuite-tmp-XXXX',
+                                    UNLINK => 1);
+(my $fh_tmp, my $tmpout) = tempfile(TEMPLATE => '/tmp/audit-testsuite-tmp-XXXX',
+                                    UNLINK => 1);
+
+###
+# tests
+
+# get the tty of this test shell
+system("tty | sed 's_/dev/__' > $ttyout");
+my $tty = <$fh_tty>;
+chomp($tty);
+
+# provoke a LOGIN record if one doesn't already exist since the last
+# boot at login time.
+system("echo \$\$ > $tmpout; exec echo \$(id -u) > /proc/self/loginuid");
+
+# get the PID of the login process from the test session shell
+# try to grab PID from the environment (NOTE: requires bash)
+my $pid = <$fh_tmp>;
+chomp($pid);
+
+# test for the LOGIN message
+my $result = system("ausearch -m LOGIN -p $pid -ts recent > $stdout 2> $stderr");
+ok($result, 0);
+
+# test if the LOGIN record was generated correctly for this test shell
+my $line;
+my $found_msg = 0;
+while ($line = <$fh_out>) {
+	# test if we generate a LOGIN record with the correct pid and tty
+	if ($line =~ /^type=LOGIN /) {
+		if ($line =~ / pid=$pid / and
+		    $line =~ / tty=$tty /) {
+			$found_msg = 1;
+		}
+	}
+}
+ok($found_msg);
+
+###
+# cleanup
+
+system("auditctl -D >& /dev/null");
+


### PR DESCRIPTION
test: RFE: add a tty field to the AUDIT_LOGIN event #2
https://github.com/linux-audit/audit-kernel/issues/2

Signed-off-by: Richard Guy Briggs <rgb@redhat.com>