### PR TITLE
RFE: add test support for session ID user filter

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,6 +8,7 @@ SUBDIRS := \
 	file_create \
 	file_delete \
 	file_rename \
+	filter_sessionid \
 	syscalls_file \
 	user_msg
 

--- a/tests/filter_sessionid/Makefile
+++ b/tests/filter_sessionid/Makefile
@@ -1,0 +1,8 @@
+TARGETS=$(patsubst %.c,%,$(wildcard *.c))
+
+LDLIBS += -lpthread
+
+all: $(TARGETS)
+clean:
+	rm -f $(TARGETS)
+

--- a/tests/filter_sessionid/test
+++ b/tests/filter_sessionid/test
@@ -1,0 +1,99 @@
+#!/usr/bin/perl
+
+use strict;
+
+use Test;
+BEGIN { plan tests => 3 }
+
+use File::Temp qw/ tempdir tempfile /;
+
+###
+# functions
+
+sub key_gen {
+	my @chars = ("A".."Z", "a".."z");
+	my $key = "testsuite-" . time . "-";
+	$key .= $chars[rand @chars] for 1..8;
+	return $key;
+}
+
+###
+# setup
+
+# reset audit
+system("auditctl -D >& /dev/null");
+
+# create stdout/stderr sinks
+(my $fh_out, my $stdout) = tempfile(TEMPLATE => '/tmp/audit-testsuite-out-XXXX',
+				    UNLINK => 1);
+(my $fh_err, my $stderr) = tempfile(TEMPLATE => '/tmp/audit-testsuite-err-XXXX',
+				    UNLINK => 1);
+(my $fh_out_set, my $stdout_set) = tempfile(TEMPLATE => '/tmp/audit-testsuite-out-set-XXXX',
+				    UNLINK => 1);
+(my $fh_err_set, my $stderr_set) = tempfile(TEMPLATE => '/tmp/audit-testsuite-err-set-XXXX',
+				    UNLINK => 1);
+(my $fh_ses, my $sesout) = tempfile(TEMPLATE => '/tmp/audit-testsuite-ses-XXXX',
+                                    UNLINK => 1);
+(my $fh_pid, my $pidout) = tempfile(TEMPLATE => '/tmp/audit-testsuite-pid-XXXX',
+                                    UNLINK => 1);
+
+###
+# tests
+
+my $result;
+
+# discover our sesssion ID
+system("cat /proc/self/sessionid > $sesout");
+my $sessionid = <$fh_ses>;
+chomp($sessionid);
+
+# create a key and rule
+my $key = key_gen();
+$result = system("auditctl -a always,exit -F arch=b64 -F path=/tmp/$key -F sessionid=$sessionid -k $key");
+ok($result, 0);
+$result = system("auditctl -a always,exit -F arch=b64 -F path=/tmp/${key}_set -F sessionid_set=1 -k ${key}_set");
+ok($result, 0);
+
+# send the userspace message (NOTE: requires bash)
+system("echo \$\$ > $pidout; exec touch /tmp/$key /tmp/${key}_set");
+my $pid = <$fh_pid>;
+chomp($pid);
+
+# test for the SYSCALL message
+$result = system("ausearch -i -m SYSCALL -sc open -p $pid --session $sessionid -k $key > $stdout 2> $stderr");
+ok($result, 0);
+$result = system("ausearch -i -m SYSCALL -sc open -p $pid --sessionid_set 1 -k ${key}_set > $stdout_set 2> $stderr_set");
+ok($result, 0);
+
+# test if we generate the SYSCALL record correctly
+my $line;
+my $syscall_msg_match = 0;
+my $syscall_msg_match_set = 0;
+while ($line = <$fh_out>) {
+	# test if SYSCALL record matches
+	if ($line =~ m?^type=SYSCALL ? and
+	    $line =~ m? pid=$pid ? and
+	    $line =~ m? ses=$sessionid ? and
+	    $line =~ m? key=$key ?) {
+		$syscall_msg_match = 1;
+		last;
+	}
+}
+ok($syscall_msg_match);
+while ($line = <$fh_out_set>) {
+	# test if SYSCALL record matches
+	if ($line =~ m?^type=SYSCALL ? and
+	    $line =~ m? pid=$pid ? and
+	    $line =~ m? ses=$sessionid ? and
+	    $line =~ m? key=${key}_set ?) {
+		$syscall_msg_match_set = 1;
+		last;
+	}
+}
+ok($syscall_msg_match_set);
+
+###
+# cleanup
+
+system("auditctl -D >& /dev/null");
+


### PR DESCRIPTION
```
test: RFE: add a session ID filter to the kernel's user filter
https://github.com/linux-audit/audit-kernel/issues/4
```

Signed-off-by: Richard Guy Briggs rgb@redhat.com
