### PR TITLE
[WIP] BUG: better compatibility with RHEL6 and other distributions

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -33,6 +33,11 @@ ifneq ($(MACHINE),$(filter i386 x86_64,$(MACHINE)))
 	TESTS := $(filter-out syscall_socketcall,$(TESTS))
 endif
 
+# tests not suitable for RHEL6
+ifeq ($(DISTRO), RHEL6)
+	TESTS := $(filter-out exec_name,$(TESTS))
+endif
+
 .PHONY: all test clean
 
 all: 


### PR DESCRIPTION
This PR adds 

  * testsuite compatibility with RHEL6,
  * DISTRO environment variable describing SUT, 
  * an example of using DISTRO in exec_name test and 
  * minor updates in README.

Resolves https://github.com/linux-audit/audit-testsuite/issues/19