### PR TITLE
BUG: syscalls_file only works on 64-bit systems (issue #17)

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,6 +2,7 @@
 export CFLAGS+=-g -O0 -Wall -D_GNU_SOURCE
 
 DISTRO := $(shell ./os_detect)
+MODE := $(shell [ $(shell uname -i) == "i386" ] && echo "32" || echo "64")
 
 SUBDIRS := \
 	exec_execve \
@@ -22,7 +23,11 @@ all:
 	chmod +x */test
 
 test: all
-	@DISTRO="$(DISTRO)" SUBDIRS="$(SUBDIRS)" PATH=/usr/bin:/bin:/usr/sbin:/sbin ./runtests.pl
+	@DISTRO="$(DISTRO)"                 \
+	 MODE="$(MODE)"                     \
+	 SUBDIRS="$(SUBDIRS)"               \
+	 PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+	 ./runtests.pl
 
 clean: 
 	@for subdir in $(SUBDIRS); do \

--- a/tests/exec_execve/test
+++ b/tests/exec_execve/test
@@ -43,8 +43,7 @@ system("auditctl -D >& /dev/null");
 
 # set the audit-by-executable filter
 my $key = key_gen();
-system("auditctl -a always,exit -F arch=b64 -S execve -k $key");
-system("auditctl -a always,exit -F arch=b32 -S execve -k $key");
+system("auditctl -a always,exit -F arch=b$ENV{MODE} -S execve -k $key");
 
 # test parameters
 my $test_count = 2048;

--- a/tests/filter_exclude/test
+++ b/tests/filter_exclude/test
@@ -105,7 +105,7 @@ system("auditctl -d exclude,always -F obj_user=$obj_user >/dev/null 2>&1");
 $result = system("auditctl -a exclude,always -F msgtype=$msgtype -F pid=$pid -F uid=$uid -F gid=$gid -F auid=$auid -F subj_user=$subj_user -F subj_role=$subj_role -F subj_type=$subj_type -F subj_sen=$subj_sen -F subj_clr=$subj_clr");
 ok($result, 0);
 
-$result = system("auditctl -a exit,always -F arch=b64 -S all -F path=/tmp/$key");
+$result = system("auditctl -a exit,always -F arch=b$ENV{MODE} -S all -F path=/tmp/$key");
 ok($result, 0);
 
 open(my $tmpfile, ">", "/tmp/$key");

--- a/tests/syscalls_file/test
+++ b/tests/syscalls_file/test
@@ -39,7 +39,7 @@ my $result;
 
 # audit all open() syscalls on 64-bit systems
 my $key = key_gen();
-$result = system("auditctl -a always,exit -F arch=b64 -S open -k $key");
+$result = system("auditctl -a always,exit -F arch=b$ENV{MODE} -S open -k $key");
 ok($result, 0);
 
 # create a new file


### PR DESCRIPTION
all: compatibility with 32 bit architectures

Adding rules which require arch field should respect machine HW
architecture (either 32 or 64 bit). A new environment variable
was introduced for this purpose:

  MODE := 32 | 64

It is detected in tests/Makefile prior to tests execution. At the
time being the only supported 32 bit architecture is i386. All
tests using arch field were updated to use MODE variable.

Signed-off-by: Ondrej Moris <omoris@redhat.com>

Resolves #17 