### PR TITLE
BUG: split "id" line in case SELinux isn't enabled

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -13,12 +13,12 @@ for (@dirs) {
 }
 
 my $output = `id`;
-$output =~ /uid=\d+\((\w+)\).*context=(\w+):(\w+):(\w+)/;
-
+$output =~ /uid=\d+\((\w+)\).*/;
 my $unix_user = $1;
-my $selinux_user = $2;
-my $selinux_role = $3;
-my $selinux_type = $4;
+$output =~ /context=(\w+):(\w+):(\w+)/;
+my $selinux_user = $1;
+my $selinux_role = $2;
+my $selinux_type = $3;
 
 # Sanity checks prior to test execution.
 die ("These tests are intended to be run as root\n") unless $unix_user eq "root";


### PR DESCRIPTION
This was necessary for a Debian 686 system, as a result of a "These
tests are intended to be run as root" error.

Signed-off-by: Richard Guy Briggs <rgb@redhat.com>