### PR TITLE
BUG: use next level Makefile for individual tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all:
 	@set -e; for i in $(SUBDIRS); do $(MAKE) -C $$i all ; done
 
 clean:
-	@set -e; for i in $(SUBDIRS); do $(MAKE) -C $$i clean ; done
+	make -C tests clean
 
 test:
 	make -C tests test


### PR DESCRIPTION
   \# cd ~/audit-testsuite/
   \# HARNESS_VERBOSE=1 HARNESS_OPTIONS="c" SUBDIRS="socketcall_32bit" make -e clean

   make[1]: *** socketcall_32bit: No such file or directory.  Stop.
   Makefile:7: recipe for target 'clean' failed

Signed-off-by: Richard Guy Briggs <rgb@redhat.com>