### PR TITLE
RFE: add NETFILTER_PKT tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,6 +13,7 @@ SUBDIRS := \
 	filter_exclude \
 	filter_sessionid \
 	login_tty \
+	netfilter_pkt \
 	syscalls_file \
 	syscall_socketcall \
 	user_msg

--- a/tests/netfilter_pkt/Makefile
+++ b/tests/netfilter_pkt/Makefile
@@ -1,0 +1,7 @@
+TARGETS=$(patsubst %.c,%,$(wildcard *.c))
+
+LDLIBS += -lpthread
+
+all: $(TARGETS)
+clean:
+	rm -f $(TARGETS)

--- a/tests/netfilter_pkt/test
+++ b/tests/netfilter_pkt/test
@@ -4,7 +4,7 @@ use strict;
 my $debug = 0;
 
 use Test;
-BEGIN { plan tests => 1 + 4 * 2 }
+BEGIN { plan tests => 1 + 6 * 2 }
 
 use File::Temp qw/ tempfile /;
 
@@ -28,25 +28,44 @@ system("auditctl -D >& /dev/null");
 
 ###
 # tests
+my $port = "42424";
 my @tests = (
 	"ipv4_icmp",
 	"ipv6_icmp",
 	"ipv4_udp",
 	"ipv6_udp",
+	"ipv4_tcp",
+	"ipv6_tcp",
 );
-my @proto = ( "", "6", "", "6");
-my @chain = ( "INPUT", "INPUT", "INPUT", "INPUT");
+my @fam = ( "", "6", "", "6", "", "6");
+my @chain = ( "INPUT", "INPUT", "INPUT", "INPUT", "INPUT", "INPUT");
+my @saddr = ( "127.0.0.1", "::1", "127.0.0.1", "::1", "127.0.0.1", "::1");
+my @daddr = ( "127.0.0.1", "::1", "127.0.0.1", "::1", "127.0.0.1", "::1");
+my @proto = ( "icmp", "ipv6-icmp", "udp", "udp", "tcp", "tcp");
 my @param = (
 	"-i lo -p icmp --icmp-type echo-request",
 	"-i lo -p icmpv6 --icmpv6-type echo-request",
-	"-i lo -p udp --dport 42424",
-	"-i lo -p udp --dport 42424",
+	"-i lo -p udp --dport $port",
+	"-i lo -p udp --dport $port",
+	"-i lo -p tcp --dport $port",
+	"-i lo -p tcp --dport $port",
 );
+my @setup = (
+	"",
+	"",
+	"",
+	"",
+	"nc -l $daddr[4] $port",
+	"nc -l $daddr[5] $port",
+);
+my @pid;
 my @trig = (
-	"ping -q -c 1 127.0.0.1 >/dev/null 2>&1",
-	"ping -q -c 1 ::1 >/dev/null 2>&1",
-	"exec 3<>/dev/udp/127.0.0.1/42424 >/dev/null 2>&1;echo hi >&3",
-	"exec 4<>/dev/udp/::1/42424 >/dev/null 2>&1;echo hi >&4",
+	"ping -q -c 1 $daddr[0] >/dev/null 2>&1",
+	"ping -q -c 1 $daddr[1] >/dev/null 2>&1",
+	"exec 3<>/dev/udp/$daddr[2]/$port >/dev/null 2>&1;echo hi >&3",
+	"exec 4<>/dev/udp/$daddr[3]/$port >/dev/null 2>&1;echo hi >&4",
+	"exec 5<>/dev/tcp/$daddr[4]/$port >/dev/null 2>&1",
+	"exec 5<>/dev/tcp/$daddr[5]/$port >/dev/null 2>&1",
 );
 my @mark;
 my @found;
@@ -58,12 +77,21 @@ for (0..$#tests) {
 }
 +my $fields = 5;
 
+# do any setup needed
+for (0..$#tests) {
+	if ($setup[$_] ne "") {
+		if (!($pid[$_] = fork())) {
+			system("$setup[$_]");
+			exit;
+		}
+	}
+}
 #
 # set the iptables filters
 for (0..$#tests) {
-	system("ip" . $proto[$_] . "tables -I " . $chain[$_] . " "
+	system("ip" . $fam[$_] . "tables -I " . $chain[$_] . " "
 		. $param[$_] . " -j AUDIT --type accept");
-	system("ip" . $proto[$_] . "tables -I " . $chain[$_] . " -t mangle "
+	system("ip" . $fam[$_] . "tables -I " . $chain[$_] . " -t mangle "
 		. $param[$_] . " -j MARK --set-mark 0x" . $mark[$_]);
 }
 sleep 1;
@@ -83,9 +111,15 @@ ok($result, 0);
 my $line;
 while ($line = <$fh_out>) {
 	for (0..$#tests) {
-		if ($line =~ / mark=0x$mark[$_] /) {
-			$found[$_] += 1;
-			$fields[$_] += () = $line =~ / [^ =]*=[^ =]*/g;
+		if (!$found[$_] && $line =~ / mark=0x$mark[$_] / ) {
+			if ($line =~ / saddr=$saddr[$_] /
+			    && $line =~ / daddr=$daddr[$_] /
+			    && $line =~ / proto=$proto[$_] / ) {
+				$found[$_] = 1;
+				$fields[$_] += () = $line =~ / [^ =]*=[^ =]*/g;
+			} else {
+				print $line;
+			}
 		}
 	}
 }
@@ -94,16 +128,18 @@ for (0..$#tests) {
 }
 
 for (0..$#tests) {
-	ok($fields[$_] == $fields); # Correct number of fields?
+	ok($fields[$_] == $fields); # $_ Correct number of fields?
 }
 
 ###
 # cleanup
-
 for (0..$#tests) {
-	system("ip" . $proto[$_] . "tables -D " . $chain[$_] . " "
+	system("ip" . $fam[$_] . "tables -D " . $chain[$_] . " "
 		. $param[$_] . " -j AUDIT --type accept");
-	system("ip" . $proto[$_] . "tables -D " . $chain[$_] . " -t mangle "
+	system("ip" . $fam[$_] . "tables -D " . $chain[$_] . " -t mangle "
 		. $param[$_] . " -j MARK --set-mark 0x" . $mark[$_]);
+	if ($pid[$_]) {
+		kill($pid[$_]);
+	}
 }
 system("auditctl -D >& /dev/null");

--- a/tests/netfilter_pkt/test
+++ b/tests/netfilter_pkt/test
@@ -61,7 +61,7 @@ my @setup = (
 my @pid;
 my @trig = (
 	"ping -q -c 1 $daddr[0] >/dev/null 2>&1",
-	"ping -q -c 1 $daddr[1] >/dev/null 2>&1",
+	"ping6 -q -c 1 $daddr[1] >/dev/null 2>&1",
 	"exec 3<>/dev/udp/$daddr[2]/$port >/dev/null 2>&1;echo hi >&3",
 	"exec 4<>/dev/udp/$daddr[3]/$port >/dev/null 2>&1;echo hi >&4",
 	"exec 5<>/dev/tcp/$daddr[4]/$port >/dev/null 2>&1",

--- a/tests/netfilter_pkt/test
+++ b/tests/netfilter_pkt/test
@@ -1,0 +1,109 @@
+#!/usr/bin/perl
+
+use strict;
+my $debug = 0;
+
+use Test;
+BEGIN { plan tests => 1 + 4 * 2 }
+
+use File::Temp qw/ tempfile /;
+
+my $basedir = $0;
+$basedir =~ s|(.*)/[^/]*|$1|;
+
+###
+# functions
+
+###
+# setup
+
+# reset audit
+system("auditctl -D >& /dev/null");
+
+# create stdout/stderr sinks
+(my $fh_out, my $stdout) = tempfile(TEMPLATE => '/tmp/audit-testsuite-out-XXXX',
+				    UNLINK => 1);
+(my $fh_err, my $stderr) = tempfile(TEMPLATE => '/tmp/audit-testsuite-err-XXXX',
+				    UNLINK => 1);
+
+###
+# tests
+my @tests = (
+	"ipv4_icmp",
+	"ipv6_icmp",
+	"ipv4_udp",
+	"ipv6_udp",
+);
+my @proto = ( "", "6", "", "6");
+my @chain = ( "INPUT", "INPUT", "INPUT", "INPUT");
+my @param = (
+	"-i lo -p icmp --icmp-type echo-request",
+	"-i lo -p icmpv6 --icmpv6-type echo-request",
+	"-i lo -p udp --dport 42424",
+	"-i lo -p udp --dport 42424",
+);
+my @trig = (
+	"ping -q -c 1 127.0.0.1 >/dev/null 2>&1",
+	"ping -q -c 1 ::1 >/dev/null 2>&1",
+	"exec 3<>/dev/udp/127.0.0.1/42424 >/dev/null 2>&1;echo hi >&3",
+	"exec 4<>/dev/udp/::1/42424 >/dev/null 2>&1;echo hi >&4",
+);
+my @mark;
+my @found;
+my @fields;
+for (0..$#tests) {
+	$mark[$_] = sprintf("%x", int(rand(0xffffffff)));
+	$found[$_] = 0;
+	$fields[$_] = 0;
+}
++my $fields = 5;
+
+#
+# set the iptables filters
+for (0..$#tests) {
+	system("ip" . $proto[$_] . "tables -I " . $chain[$_] . " "
+		. $param[$_] . " -j AUDIT --type accept");
+	system("ip" . $proto[$_] . "tables -I " . $chain[$_] . " -t mangle "
+		. $param[$_] . " -j MARK --set-mark 0x" . $mark[$_]);
+}
+sleep 1;
+
+# run the tests
+for (0..$#tests) {
+	system($trig[$_]);
+}
+
+system("sleep 1; sync");
+
+# test if we generate any audit records from the filter rules
+my $result = system("ausearch -i -m NETFILTER_PKT -ts recent > $stdout 2> $stderr");
+ok($result, 0);
+
+# test if we generate the NETFILTER_PKT records correctly
+my $line;
+while ($line = <$fh_out>) {
+	for (0..$#tests) {
+		if ($line =~ / mark=0x$mark[$_] /) {
+			$found[$_] += 1;
+			$fields[$_] += () = $line =~ / [^ =]*=[^ =]*/g;
+		}
+	}
+}
+for (0..$#tests) {
+	ok($found[$_]); # Was the nfmarked parcket found?
+}
+
+for (0..$#tests) {
+	ok($fields[$_] == $fields); # Correct number of fields?
+}
+
+###
+# cleanup
+
+for (0..$#tests) {
+	system("ip" . $proto[$_] . "tables -D " . $chain[$_] . " "
+		. $param[$_] . " -j AUDIT --type accept");
+	system("ip" . $proto[$_] . "tables -D " . $chain[$_] . " -t mangle "
+		. $param[$_] . " -j MARK --set-mark 0x" . $mark[$_]);
+}
+system("auditctl -D >& /dev/null");


### PR DESCRIPTION
Test for simplified normalized NETFILTER_PKT audit message.
Check for receipt of each nfmarked packet and for correct number of fields.

See: https://github.com/linux-audit/audit-kernel/issues/11
Signed-off-by: Richard Guy Briggs <rgb@redhat.com>