### PR TITLE
RFE: execve/BPRM_FCAPS manual test

### DIFF
--- a/tests_manual/syscall_execve_noBPRM_FCAPS/Makefile
+++ b/tests_manual/syscall_execve_noBPRM_FCAPS/Makefile
@@ -1,0 +1,8 @@
+TARGETS=$(patsubst %.c,%,$(wildcard *.c))
+
+LDLIBS += -lpthread
+
+all: $(TARGETS)
+
+clean:
+	rm -f $(TARGETS)

--- a/tests_manual/syscall_execve_noBPRM_FCAPS/README.txt
+++ b/tests_manual/syscall_execve_noBPRM_FCAPS/README.txt
@@ -24,7 +24,7 @@ How to run the test:
 
 	# cd tests_manual/syscall_execve_noBPRM_FCAPS
 
-2) As rot, set up the test, which adds an audit rule to log all execve syscalls
+2) As root, set up the test, which adds an audit rule to log all execve syscalls
 where the uid and euid are not equivalent.
 
 	# ./setup

--- a/tests_manual/syscall_execve_noBPRM_FCAPS/README.txt
+++ b/tests_manual/syscall_execve_noBPRM_FCAPS/README.txt
@@ -1,0 +1,55 @@
+Title: check BPRM_FCAPS record not generated when executing setuid applications
+
+
+Description:
+The audit subsystem is adding a BPRM_FCAPS record when auditing setuid
+application execution. This is not expected as it was supposed to be limited to
+when the file system actually had capabilities in an extended attribute.
+This was observed on Fedora kernel 4.1.5-200.fc22.x86_64.
+
+Reproducer:
+# auditctl -a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -F key=setuid-exec
+# su - root
+# ausearch --start recent -k setuid-exec -i
+
+Goal:
+Make certain a BPRM_FCAPS record is not generated because it lists all
+capabilities making the event really ugly to parse what is
+happening.  The PATH record correctly records the setuid bit and owner.
+
+
+How to run the test:
+
+1) As root, change to the working directory of the test.
+
+	# cd tests_manual/syscall_execve_noBPRM_FCAPS
+
+2) As rot, set up the test, which adds an audit rule to log all execve syscalls
+where the uid and euid are not equivalent.
+
+	# ./setup
+
+3) Transition from unprivileged user to superuser
+
+	$ su - root
+
+4) As root, run the test itself that looks for execve syscall records since
+this last rule was added and searches for a BPRM_FCAPS record accompanying the
+syscall record in that event.
+
+	# ./test
+
+If there are BPRM_FCAPS records, it will list which commands cause the records.
+
+5) As root, restore the config file back to its previous state and delete the
+audit rule.
+
+	# ./cleanup
+
+
+Todo:
+Automate the test so that manually running the transition from unprivileged
+account to root is not necessary.
+
+
+Author: Richard Guy Briggs <rgb@redhat.com> 2017-03-01

--- a/tests_manual/syscall_execve_noBPRM_FCAPS/cleanup
+++ b/tests_manual/syscall_execve_noBPRM_FCAPS/cleanup
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-key=ghak8-setuid-exec
+key=ghak16-setuid-exec
 checkpoint=/tmp/audit_testsuite-syscall_execve_noBPRM_FCAPS-checkpoint
 
 auditctl -d always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k $key

--- a/tests_manual/syscall_execve_noBPRM_FCAPS/cleanup
+++ b/tests_manual/syscall_execve_noBPRM_FCAPS/cleanup
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+key=ghak8-setuid-exec
+checkpoint=/tmp/audit_testsuite-syscall_execve_noBPRM_FCAPS-checkpoint
+
+auditctl -d always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k $key
+rm $checkpoint
+

--- a/tests_manual/syscall_execve_noBPRM_FCAPS/setup
+++ b/tests_manual/syscall_execve_noBPRM_FCAPS/setup
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+key=ghak8-setuid-exec
+checkpoint=/tmp/audit_testsuite-syscall_execve_noBPRM_FCAPS-checkpoint
+
+ausearch -ts recent --checkpoint $checkpoint
+auditctl -a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k $key
+

--- a/tests_manual/syscall_execve_noBPRM_FCAPS/setup
+++ b/tests_manual/syscall_execve_noBPRM_FCAPS/setup
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-key=ghak8-setuid-exec
+key=ghak16-setuid-exec
 checkpoint=/tmp/audit_testsuite-syscall_execve_noBPRM_FCAPS-checkpoint
 
 ausearch -ts recent --checkpoint $checkpoint
-auditctl -a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k $key
+auditctl -A always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k $key
 

--- a/tests_manual/syscall_execve_noBPRM_FCAPS/test
+++ b/tests_manual/syscall_execve_noBPRM_FCAPS/test
@@ -1,0 +1,82 @@
+#!/usr/bin/perl
+
+use strict;
+use File::Temp qw/ tempfile /;
+use Test;
+BEGIN { plan tests => 2 }
+
+my $basedir = $0;
+$basedir =~ s|(.*)/[^/]*|$1|;
+
+###
+# functions
+
+###
+# setup
+
+# create stdout/stderr sinks
+(my $fh_out, my $stdout) = tempfile(TEMPLATE => '/tmp/audit-testsuite-out-XXXX',
+				    UNLINK => 1);
+(my $fh_err, my $stderr) = tempfile(TEMPLATE => '/tmp/audit-testsuite-err-XXXX',
+				    UNLINK => 1);
+(my $fh_out2, my $stdout2) = tempfile(
+				TEMPLATE => '/tmp/audit-testsuite-out-XXXX',
+				UNLINK => 1);
+(my $fh_err2, my $stderr2) = tempfile(
+				TEMPLATE => '/tmp/audit-testsuite-err-XXXX',
+				UNLINK => 1);
+
+###
+# tests
+
+# run the test
+my $line;
+my $key = "ghak8-setuid-exec";
+my $checkpoint = "/tmp/audit_testsuite-syscall_execve_noBPRM_FCAPS-checkpoint";
+
+# test if we generate any audit records from the filter rule
+my $result = system("ausearch --checkpoint $checkpoint --start checkpoint -i --syscall execve -k $key > $stdout 2> $stderr");
+ok($result, 0); # Did we find any records matching the search key?
+
+# test if we generate the PATH record with null name field
+my $found_bprm_fcaps = 0;
+my $id = "";
+my $msgtime = "";
+my $msgdate = "";
+my $line2;
+seek($fh_out, 0, 0);
+seek($fh_err, 0, 0);
+while ($line = <$fh_out>) {
+	if ($line =~ /^type=SYSCALL / && $line =~ / syscall=execve /) {
+		my $bprm_fcaps = 0;
+		my ($comm) = ($line =~ / comm=([^ ]+) /);
+		my $proctitle = "";
+		($id) = ($line =~ / msg=audit\(.*:([0-9]*)\).* /);
+		($msgdate) = ($line =~ / msg=audit\(([^ ]*) .*:[0-9]*\).* /);
+		($msgtime) = ($line =~ / msg=audit\([^ ]* (.*):[0-9]*\).* /);
+		seek($fh_out2, 0, 0);
+		system("ausearch -i -ts $msgdate -a $id -k $key >$stdout2 2>$stderr2");
+		while ($line2 = <$fh_out2>) {
+			if ($line2 =~ /^type=BPRM_FCAPS /) {
+				$bprm_fcaps = 1;
+			}
+			if ($line2 =~ /^type=PROCTITLE /) {
+				$line2 =~ / proctitle=(.*)$/;
+				$proctitle = $1;
+			}
+		}
+		if ($bprm_fcaps) {
+			$found_bprm_fcaps = 1;
+			print "  msg ID:$id date:$msgdate time:$msgtime\n";
+			if ($proctitle != "") {
+				print "  BPRM_FCAPS found: \"$proctitle\"\n";
+			} else {
+				print "  BPRM_FCAPS found: \"$comm\"\n";
+			}
+		}
+	}
+}
+ok($found_bprm_fcaps, 0); # Were no execve SYSCALL BPRM_FCAPS records detected?
+
+###
+# cleanup

--- a/tests_manual/syscall_execve_noBPRM_FCAPS/test
+++ b/tests_manual/syscall_execve_noBPRM_FCAPS/test
@@ -31,12 +31,12 @@ $basedir =~ s|(.*)/[^/]*|$1|;
 
 # run the test
 my $line;
-my $key = "ghak8-setuid-exec";
+my $key = "ghak16-setuid-exec";
 my $checkpoint = "/tmp/audit_testsuite-syscall_execve_noBPRM_FCAPS-checkpoint";
 
 # test if we generate any audit records from the filter rule
 my $result = system("ausearch --checkpoint $checkpoint --start checkpoint -i --syscall execve -k $key > $stdout 2> $stderr");
-ok($result, 0); # Did we find any records matching the search key?
+ok($result, 0); # Did we find any records matching the search key?  Ran setup?
 
 # test if we generate the PATH record with null name field
 my $found_bprm_fcaps = 0;


### PR DESCRIPTION
Check to verify that execve syscall rules don't generate BPRM_FCAPS auxilliary
records when triggered by a transition from unprivileged user to root.

See: https://github.com/linux-audit/audit-kernel/issues/16

Signed-off-by: Richard Guy Briggs <rgb@redhat.com>