### PR TITLE
RFE: add test for audit_filter_rules cred memory leak

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,6 +11,7 @@ TESTS := \
 	file_delete \
 	file_rename \
 	filter_exclude \
+	filter_rules-memleak \
 	filter_sessionid \
 	login_tty \
 	syscalls_file \

--- a/tests/filter_rules-memleak/Makefile
+++ b/tests/filter_rules-memleak/Makefile
@@ -1,0 +1,8 @@
+TARGETS=$(patsubst %.c,%,$(wildcard *.c))
+
+LDLIBS += -lpthread
+
+all: $(TARGETS)
+
+clean:
+	rm -f $(TARGETS)

--- a/tests/filter_rules-memleak/README.txt
+++ b/tests/filter_rules-memleak/README.txt
@@ -1,0 +1,33 @@
+Title: audit_filter_rules cred structure memory leak
+
+
+Description:
+This test detects kernels that leak cred structures in
+kernel/auditsc.c:audit_filter_rules() when two rules matching the same event
+are tested in decreasing priority (syscall, then watch?).
+
+It does this by setting up two rules that should both match a trigger condition
+but expecting the latter rule to not be executed due to the first having a
+higher rule execution priority.  The exit condition for the latter rule forgets
+to put_cred().  A trigger condition is provoked many times while measuring
+memory conditions to detect the bug.
+
+
+How to run the test:
+
+- Change to the working directory of the test.
+
+	cd tests_manual/filter_rules-memleak
+
+- Run the test itself that records the current amount of memory, runs a
+  triggering command that is expected to match both rules many times, then
+  again records the amount of memory used checking for a significant
+  difference.
+
+	./test
+
+  If there is, it will report unusual memory use on output.
+
+
+
+Author: Richard Guy Briggs <rgb@redhat.com> 2017-04-11

--- a/tests/filter_rules-memleak/test
+++ b/tests/filter_rules-memleak/test
@@ -1,0 +1,72 @@
+#!/usr/bin/perl
+
+use strict;
+use File::Temp qw/ tempfile /;
+use Test;
+BEGIN { plan tests => 2 }
+
+my $basedir = $0;
+$basedir =~ s|(.*)/[^/]*|$1|;
+
+###
+# functions
+
+sub key_gen {
+	my @chars = ("A".."Z", "a".."z");
+	my $key = "testsuite-" . time . "-";
+	$key .= $chars[rand @chars] for 1..8;
+	return $key;
+}
+
+###
+# setup
+
+# create stdout/stderr sinks
+(my $fh_out, my $stdout) = tempfile(TEMPLATE => '/tmp/audit-testsuite-out-XXXX',
+				    UNLINK => 1);
+(my $fh_err, my $stderr) = tempfile(TEMPLATE => '/tmp/audit-testsuite-err-XXXX',
+				    UNLINK => 1);
+my $key = key_gen();
+my $testdir = "/tmp/$key";
+my $testfile = "/tmp/$key/test.txt";
+mkdir $testdir;
+
+system("auditctl -a always,exit -F arch=b64 -S open -F dir=$testdir -k $key-1");
+system("auditctl -a always,exit -F arch=b64 -S open -F path=$testfile -k $key-2");
+
+system("grep cred_jar /proc/slabinfo | awk '{print \$2}' > $stdout 2> $stderr");
+my $line;
+my $cred_jar_start;
+while ($line = <$fh_out>) {
+	($cred_jar_start) = ($line =~ /^([0-9]+)$/);
+}
+
+###
+# tests
+
+# run the test
+my $iterations = 10000;
+system("for i in \$(seq 1 $iterations);do touch $testfile; done");
+sleep 2;
+
+seek($fh_out, 0, 0);
+seek($fh_err, 0, 0);
+system("grep cred_jar /proc/slabinfo | awk '{print \$2}' > $stdout 2> $stderr");
+my $cred_jar_end;
+while ($line = <$fh_out>) {
+	($cred_jar_end) = ($line =~ /^([0-9]+)$/);
+}
+
+my $leak = ($cred_jar_start + $iterations) <= $cred_jar_end;
+ok(!$leak); # Is there a leak?
+if($leak) {
+	print "Memory leaked to cred_jar:$cred_jar_start:$cred_jar_end\n";
+}
+
+###
+# cleanup
+system("auditctl -d always,exit -F arch=b64 -S open -F dir=$testdir -k $key-1");
+system("auditctl -d always,exit -F arch=b64 -S open -F path=$testfile -k $key-2");
+
+unlink $testfile;
+rmdir $testdir;


### PR DESCRIPTION
A memory leak of the cred struct and any resources managed by it was introduced
by commit c69e8d9c01db ("CRED: Use RCU to access another task's creds and to
release a task's own creds") in the case where two rules overlap a trigger
condition but the second is assumed to be ignored due to its order priority.

See: https://github.com/linux-audit/audit-testsuite/issues/47
See: https://bugzilla.redhat.com/show_bug.cgi?id=1434560

Signed-off-by: Richard Guy Briggs <rgb@redhat.com>