### PR TITLE
tests/filter_sessionid: search for each of open and openat

### DIFF
--- a/tests/filter_sessionid/test
+++ b/tests/filter_sessionid/test
@@ -65,7 +65,10 @@ chomp($pid);
 
 # test for the SYSCALL message
 $result = system(
-"ausearch -i -m SYSCALL -sc open -sc openat -p $pid --session $sessionid -k $key > $stdout 2> $stderr"
+"ausearch -i -m SYSCALL -sc open -p $pid --session $sessionid -k $key > $stdout 2> $stderr"
+);
+$result &= system(
+"ausearch -i -m SYSCALL -sc openat -p $pid --session $sessionid -k $key >> $stdout 2>> $stderr"
 );
 ok( $result, 0 );
 


### PR DESCRIPTION
Since the ausearch command takes only a single -sc parameter, the last
one on the line, search for each seperately and append and & the results.

Signed-off-by: Richard Guy Briggs <rgb@redhat.com>