### PR TITLE
tests: syscall patterns fixes in tests for aarch64

### DIFF
--- a/tests/file_delete/test
+++ b/tests/file_delete/test
@@ -81,7 +81,7 @@ while ( $line = <$fh_out> ) {
 
     # test if we generate a SYSCALL record
     if ( $line =~ /^type=SYSCALL / ) {
-        if ( $line =~ / syscall=unlink / and $line =~ / success=yes / ) {
+        if ( $line =~ / syscall=unlink(at)? /  and $line =~ / success=yes / ) {
             $found_syscall = 1;
         }
     }

--- a/tests/file_rename/test
+++ b/tests/file_rename/test
@@ -82,7 +82,7 @@ while ( $line = <$fh_out> ) {
 
     # test if we generate a SYSCALL record
     if ( $line =~ /^type=SYSCALL / ) {
-        if ( $line =~ / syscall=rename / and $line =~ / success=yes / ) {
+        if ( $line =~ / syscall=rename(at)? / and $line =~ / success=yes / ) {
             $found_syscall = 1;
         }
     }

--- a/tests/filter_exclude/test
+++ b/tests/filter_exclude/test
@@ -152,7 +152,7 @@ while ( $line = <$fh_out2> ) {
 
     # test if we generate a SYSCALL unlink record
     if ( $line =~ /^type=SYSCALL / ) {
-        if ( $line =~ / syscall=unlink / ) {
+        if ( $line =~ / syscall=unlink(at)? / ) {
             $found_msg = 1;
         }
     }

--- a/tests/syscalls_file/test
+++ b/tests/syscalls_file/test
@@ -39,20 +39,21 @@ my $dir = tempdir( TEMPLATE => '/tmp/audit-testsuite-XXXX', CLEANUP => 1 );
 ###
 # tests
 
-my $result;
-
 # audit all open() syscalls on 64-bit systems
 my $key = key_gen();
-$result = system(
-    "auditctl -a always,exit -F arch=b$ENV{MODE} -S open -S openat -k $key");
-ok( $result, 0 );
+my $result_open = system(
+    "auditctl -a always,exit -F arch=b$ENV{MODE} -S open -k $key 2> $stderr");
+my $result_openat = system(
+    "auditctl -a always,exit -F arch=b$ENV{MODE} -S openat -k $key");
+
+ok($result_open == 0 or $result_openat == 0);
 
 # create a new file
 ( my $fh, my $filename ) =
   tempfile( TEMPLATE => $dir . "/file-XXXX", UNLINK => 1 );
 
 # test if we generate any audit records
-$result = system("ausearch -i -k $key > $stdout 2> $stderr");
+my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
 ok( $result, 0 );
 
 # test if we generate the SYSCALL record correctly
@@ -64,7 +65,7 @@ while ( $line = <$fh_out> ) {
 
     # test if we generate a SYSCALL record
     if ( $line =~ /^type=SYSCALL /
-        and ( $line =~ / syscall=open / or $line =~ / syscall=openat / ) )
+        and ( $line =~ / syscall=open(at)? / ) )
     {
         $found_syscall = 1;
     }


### PR DESCRIPTION
On aarch64 architecture syscalls used in tests are different
than on the other architectures (eg. openat instead of open
which is not available at all). Previously, these differences
caused various tests to fail even though correct events were
triggered. With patterns corrected all tests pass.

Signed-off-by: Ondrej Moris <omoris@redhat.com>