### PR TITLE
tests: update rules to select correct arch

### DIFF
--- a/tests/exec_name/test
+++ b/tests/exec_name/test
@@ -59,7 +59,8 @@ sub do_test {
     # set the audit-by-executable filter
     my $key = key_gen();
     system(
-        "auditctl -a always,exit -F $rule -F arch=b64 -S exit_group -k $key");
+"auditctl -a always,exit -F $rule -F arch=b$ENV{MODE} -S exit_group -k $key"
+    );
 
     # run the watched executable
     system("$exec > /dev/null 2> /dev/null");

--- a/tests/filter_sessionid/test
+++ b/tests/filter_sessionid/test
@@ -54,7 +54,7 @@ chomp($sessionid);
 # create a key and rule
 my $key = key_gen();
 $result = system(
-"auditctl -a always,exit -F arch=b64 -F path=/tmp/$key -F sessionid=$sessionid -k $key"
+"auditctl -a always,exit -F arch=b$ENV{MODE} -F path=/tmp/$key -F sessionid=$sessionid -k $key"
 );
 ok( $result, 0 );
 

--- a/tests/lost_reset/test
+++ b/tests/lost_reset/test
@@ -57,7 +57,9 @@ for ( $i = 0 ; $i < $iterations ; $i++ ) {    # iteration count
 
     # Add rule to generate audit queue events from floodping
     $result =
-      system("auditctl -a exit,always -S all -F pid=$ping_pid >/dev/null 2>&1");
+      system(
+"auditctl -a exit,always -F arch=b$ENV{MODE} -S all -F pid=$ping_pid >/dev/null 2>&1"
+      );
 
     my $counter = 0;
     my $timeout = 50;
@@ -82,7 +84,9 @@ for ( $i = 0 ; $i < $iterations ; $i++ ) {    # iteration count
     }
 
     kill 'TERM', $ping_pid;
-    system("auditctl -d exit,always -S all -F pid=$ping_pid >/dev/null 2>&1");
+    system(
+"auditctl -d exit,always -F arch=b$ENV{MODE} -S all -F pid=$ping_pid >/dev/null 2>&1"
+    );
 
     # Restart the daemon to collect messages in the log
     system("service auditd start >/dev/null 2>&1");

--- a/tests/syscall_module/test
+++ b/tests/syscall_module/test
@@ -45,9 +45,11 @@ my $result;
 
 # connect
 system(
-"auditctl -a always,exit -F arch=b64 -S init_module -S finit_module -k $key-load"
+"auditctl -a always,exit -F arch=b$ENV{MODE} -S init_module -S finit_module -k $key-load"
 );
-system("auditctl -a always,exit -F arch=b64 -S delete_module -k $key-unload");
+system(
+"auditctl -a always,exit -F arch=b$ENV{MODE} -S delete_module -k $key-unload"
+);
 
 # run the test
 my $name = "arp_tables";

--- a/tests_manual/syscall_module_path_filter/setup
+++ b/tests_manual/syscall_module_path_filter/setup
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-echo "-a always,exit -F arch=b64 -S init_module -S finit_module -k ghak8-mod-load" > /etc/audit/rules.d/tests_manual-syscall_module_path_filter.rules
+echo "-a always,exit -F arch=$(uname -i) -S init_module -S finit_module -k ghak8-mod-load" > /etc/audit/rules.d/tests_manual-syscall_module_path_filter.rules
 echo "-a never,filesystem -F fstype=0x74726163 -F key=ghak8-mod_load-ignore_tracefs" >> /etc/audit/rules.d/tests_manual-syscall_module_path_filter.rules
 echo "-a never,filesystem -F fstype=0x64626720 -F key=ghak8-mod_load-ignore_debugfs" >> /etc/audit/rules.d/tests_manual-syscall_module_path_filter.rules
 


### PR DESCRIPTION
Several tests have embedded references to 64-bit architecture rules when
they may be run on 32-bit architecture machines. Convert them from "-F
arch=b64" to "-F arch=b$ENV{MODE}" or add the arch field where it is
missing entirely.

Please see github issue
https://github.com/linux-audit/audit-testsuite/issues/78

Signed-off-by: Richard Guy Briggs <rgb@redhat.com>