### PR TITLE
RFE: do not override the PATH variable

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -49,10 +49,9 @@ list:
 	@echo
 
 test: all
-	@DISTRO="$(DISTRO)"                 \
-	 MODE="$(MODE)"                     \
-	 TESTS="$(TESTS)"                   \
-	 PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+	@DISTRO="$(DISTRO)" \
+	 MODE="$(MODE)"     \
+	 TESTS="$(TESTS)"   \
 	 ./runtests.pl
 
 clean: 


### PR DESCRIPTION
Setting up the PATH variable should be up to the user, so let's not
override it when running './runtests.pl'.

Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>