### PR TITLE
BUG: prevent ausearch race conditions

### DIFF
--- a/tests/exec_execve/test
+++ b/tests/exec_execve/test
@@ -62,6 +62,15 @@ system("$basedir/execve_arg_gen count $test_count");
 system("$basedir/execve_arg_gen size $test_size");
 system("$basedir/execve_arg_gen hex $test_hex");
 
+# make sure the records had a chance to bubble through to the logs
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
+
 # test if we generate any audit records from the filter rule
 my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
 ok( $result, 0 );

--- a/tests/exec_name/test
+++ b/tests/exec_name/test
@@ -99,11 +99,22 @@ sub do_test {
                 $expected[$_] = 0 if $_ != $exe;
             }
         }
-        system("auditctl -a always,exclude -F exe$op$execs[$exe]");
+        system(
+"auditctl -a always,exclude -F msgtype=SYSCALL -F exe$op$execs[$exe]"
+        );
     }
 
     # run the executables
     system("$_ > /dev/null 2> /dev/null") for (@execs);
+
+    # make sure the records had a chance to bubble through to the logs
+    system("auditctl -m syncmarker-$key");
+    for ( my $i = 0 ; $i < 10 ; $i++ ) {
+        if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+            last;
+        }
+        sleep(0.2);
+    }
 
     # test if we generate any audit records from the filter rule
     my $result = system("ausearch -i -k $key > $stdout 2> $stderr");

--- a/tests/file_create/test
+++ b/tests/file_create/test
@@ -65,6 +65,15 @@ my $dev_fmt = sprintf( "%02x:%02x", $dev >> 8, $dev & 0x00ff );
 my $uid_fmt = getpwuid($uid);
 my $gid_fmt = getgrgid($uid);
 
+# make sure the records had a chance to bubble through to the logs
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
+
 # test if we generate any audit records from the watch
 my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
 ok( $result, 0 );

--- a/tests/file_delete/test
+++ b/tests/file_delete/test
@@ -68,6 +68,15 @@ system("auditctl -w $dir -k $key");
 # delete file
 unlink($filename);
 
+# make sure the records had a chance to bubble through to the logs
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
+
 # test if we generate any audit records from the watch
 my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
 ok( $result, 0 );

--- a/tests/file_rename/test
+++ b/tests/file_rename/test
@@ -68,6 +68,15 @@ system("auditctl -w $dir -k $key");
 # move/rename the file
 rename( $filename, $filename . "-new" );
 
+# make sure the records had a chance to bubble through to the logs
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
+
 # test if we generate any audit records from the watch
 my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
 ok( $result, 0 );

--- a/tests/filter_exclude/test
+++ b/tests/filter_exclude/test
@@ -119,6 +119,15 @@ ok( $result, 0 );
 open( my $tmpfile, ">", "/tmp/$key" );
 close($tmpfile);
 
+# make sure the records had a chance to bubble through to the logs
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
+
 # test for the SYSCALL message provoked by creat
 $result = system(
 "ausearch -i -m SYSCALL -p $pid -ui $uid -gi $gid -ul $auid -su $subj_user:$subj_role:$subj_type:$subj_sen-$subj_clr -ts recent > $stdout 2> /dev/null"
@@ -139,7 +148,14 @@ ok( $result, 0 );
 
 unlink "/tmp/$key";
 
-system("sync");
+# make sure the records had a chance to bubble through to the logs
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
 
 # test for the SYSCALL message provoked by unlink
 $result = system(

--- a/tests/filter_sessionid/test
+++ b/tests/filter_sessionid/test
@@ -63,6 +63,15 @@ system("echo \$\$ > $pidout; exec touch /tmp/$key");
 my $pid = <$fh_pid>;
 chomp($pid);
 
+# make sure the records had a chance to bubble through to the logs
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
+
 # test for the SYSCALL message
 $result = system(
 "ausearch -i -m SYSCALL -sc open -p $pid --session $sessionid -k $key > $stdout 2> $stderr"

--- a/tests/login_tty/test
+++ b/tests/login_tty/test
@@ -10,6 +10,13 @@ use File::Temp qw/ tempdir tempfile /;
 ###
 # functions
 
+sub key_gen {
+    my @chars = ( "A" .. "Z", "a" .. "z" );
+    my $key = "testsuite-" . time . "-";
+    $key .= $chars[ rand @chars ] for 1 .. 8;
+    return $key;
+}
+
 ###
 # setup
 
@@ -54,6 +61,16 @@ system("echo \$\$ > $tmpout; exec echo \$(id -u) > /proc/self/loginuid");
 # try to grab PID from the environment (NOTE: requires bash)
 my $pid = <$fh_tmp>;
 chomp($pid);
+
+# make sure the records had a chance to bubble through to the logs
+my $key = key_gen();
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
 
 # test for the LOGIN message
 my $result =

--- a/tests/lost_reset/test
+++ b/tests/lost_reset/test
@@ -8,6 +8,13 @@ BEGIN { plan tests => 5 }
 ###
 # functions
 
+sub key_gen {
+    my @chars = ( "A" .. "Z", "a" .. "z" );
+    my $key = "testsuite-" . time . "-";
+    $key .= $chars[ rand @chars ] for 1 .. 8;
+    return $key;
+}
+
 ###
 # setup
 
@@ -110,7 +117,15 @@ ok( $result, 0 );    # Was the reset command successful?
 my $reset_rc = $1;
 ok( $reset_rc > 0 );    # Was the lost value non-zero?
 
-sleep 1;
+# make sure the records had a chance to bubble through to the logs
+my $key = key_gen();
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
 
 # find the config change event
 seek( $fh_out, 0, 0 );
@@ -118,7 +133,7 @@ seek( $fh_err, 0, 0 );
 $result = system(
 "LC_TIME=\"en_DK.utf8\" ausearch --start $startdate $starttime -i -m CONFIG_CHANGE >$stdout 2>$stderr"
 );
-ok( $result, 0 );       # Was an event found?
+ok( $result, 0 );    # Was an event found?
 
 # test if we generate the lost reset record correctly
 my $found_msg = 0;

--- a/tests/netfilter_pkt/test
+++ b/tests/netfilter_pkt/test
@@ -8,11 +8,15 @@ BEGIN { plan tests => 1 + 6 * 2 }
 
 use File::Temp qw/ tempfile /;
 
-my $basedir = $0;
-$basedir =~ s|(.*)/[^/]*|$1|;
-
 ###
 # functions
+
+sub key_gen {
+    my @chars = ( "A" .. "Z", "a" .. "z" );
+    my $key = "testsuite-" . time . "-";
+    $key .= $chars[ rand @chars ] for 1 .. 8;
+    return $key;
+}
 
 ###
 # setup
@@ -97,14 +101,21 @@ for ( 0 .. $#tests ) {
           . " -j MARK --set-mark 0x"
           . $mark[$_] );
 }
-sleep 1;
 
 # run the tests
 for ( 0 .. $#tests ) {
     system( $trig[$_] );
 }
 
-system("sleep 1; sync");
+# make sure the records had a chance to bubble through to the logs
+my $key = key_gen();
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
 
 # test if we generate any audit records from the filter rules
 my $result =

--- a/tests/syscall_module/test
+++ b/tests/syscall_module/test
@@ -7,9 +7,6 @@ BEGIN { plan tests => 6 }
 
 use File::Temp qw/ tempfile /;
 
-my $basedir = $0;
-$basedir =~ s|(.*)/[^/]*|$1|;
-
 ###
 # functions
 
@@ -55,7 +52,15 @@ system(
 my $name = "arp_tables";
 $result = system("modprobe $name >/dev/null 2>&1");
 ok( $result, 0 );    # Did the modprobe succeed?
-system("sleep 1;sync");
+
+# make sure the records had a chance to bubble through to the logs
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
 
 # test if we generate any audit records from the filter rule
 $result = system("ausearch -k $key-load > $stdout 2> $stderr");
@@ -76,7 +81,16 @@ ok($found_name);    # Was the load module found?
 
 $result = system("rmmod $name");
 ok( $result, 0 );    # Did the rmmod succeed?
-system("sleep 1;sync");
+
+# make sure the records had a chance to bubble through to the logs
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
+
 seek( $fh_out, 0, 0 );
 seek( $fh_err, 0, 0 );
 $found_name = 0;

--- a/tests/syscall_socketcall/test
+++ b/tests/syscall_socketcall/test
@@ -58,7 +58,14 @@ my $portno = 42424;
 # run the test
 system("echo Hello World. | $basedir/conn 127.0.0.1 $portno >/dev/null 2>&1");
 
-system("sleep 1;sync");
+# make sure the records had a chance to bubble through to the logs
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
 
 # test if we generate any audit records from the filter rule
 my $result = system("ausearch -i -k $key > $stdout 2> $stderr");

--- a/tests/syscalls_file/test
+++ b/tests/syscalls_file/test
@@ -52,6 +52,15 @@ ok( $result_open == 0 or $result_openat == 0 );
 ( my $fh, my $filename ) =
   tempfile( TEMPLATE => $dir . "/file-XXXX", UNLINK => 1 );
 
+# make sure the records had a chance to bubble through to the logs
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
+
 # test if we generate any audit records
 my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
 ok( $result, 0 );

--- a/tests/user_msg/test
+++ b/tests/user_msg/test
@@ -46,8 +46,15 @@ system("echo \$BASHPID\ > $tmpout; exec auditctl -m \"Testing 1 2 3 $key\"");
 my $pid = <$fh_tmp>;
 chomp($pid);
 
-# test for the userspace message
-my $result = system("ausearch -m USER -p $pid > $stdout 2> $stderr");
+# test for the userspace message (it may take some time to appear in logs)
+my $result;
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    $result = system("ausearch -m USER -p $pid > $stdout 2> $stderr");
+    if ( $result eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
 ok( $result, 0 );
 
 # test if we generate the USER record correctly


### PR DESCRIPTION
On busy machines it can happen that the record we are searching for
doesn't make it to the log file before we run ausearch.

This patch fixes this problem by adding an 'audit_sync' script, which
generates a marker user record using 'auditclt -m' and waits until the
marker appears in the audit log. This is much more reliable than the
current mix of either completely ignoring the issue or just doing an
unreliable sleep.

--
We are observing some rare random failures in our infrastructure and this seems to be the most logical explanation for them. The failures are hard to trigger, so I wasn't able to verify if this patch really fixes the problem. However, it is easy to see that the race *can* happen given the right circumstances and the solution is IMHO simple enough that it is worth applying it.