### PR TITLE
syscall_socketcall: update regexp for new field name

### DIFF
--- a/tests/syscall_socketcall/test
+++ b/tests/syscall_socketcall/test
@@ -81,7 +81,7 @@ my $found_sockaddr   = 0;
 while ( $line = <$fh_out> ) {
     if ( $line =~ /^type=SOCKADDR / ) {
         if ( $line =~
-/ : saddr=(\{ fam=|)inet (laddr=|host:)127.0.0.1 (lport=|serv:)$portno( \}|)/
+/ : saddr=(\{ fam=|\{ saddr_fam=|)inet (laddr=|host:)127.0.0.1 (lport=|serv:)$portno( \}|)/
           )
         {
             $found_sockaddr = 1;


### PR DESCRIPTION
Field 'fam' changed to 'saddr_fam' in SOCKADDR event in
audit-3.0-0.11.20190507gitf58ec40. Updated test now accepts both
fam= and saddr_fam=.

Signed-off-by: Ondrej Moris <omoris@redhat.com>