### PR TITLE
RFE: add the bpf tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -28,7 +28,8 @@ TESTS := \
 	syscall_module \
 	syscall_socketcall \
 	user_msg \
-	fanotify
+	fanotify \
+	bpf
 
 # apply any ABI restrictions to the tests
 ifneq ($(MACHINE),$(filter i386 x86_64,$(MACHINE)))

--- a/tests/bpf/Makefile
+++ b/tests/bpf/Makefile
@@ -1,0 +1,9 @@
+TARGETS=$(patsubst %.c,%,$(wildcard *.c))
+
+all: $(TARGETS)
+
+bpf: bpf.c
+	$(CC) $(CFLAGS) -o $@ $^
+
+clean:
+	rm -f $(TARGETS)

--- a/tests/bpf/bpf.c
+++ b/tests/bpf/bpf.c
@@ -1,0 +1,42 @@
+#include <string.h>
+#include <linux/filter.h>
+#include <linux/bpf.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+#define BPF_EXIT_INSN()						\
+	((struct bpf_insn) {					\
+		.code    = BPF_JMP | BPF_EXIT,			\
+			   .dst_reg = 0,					\
+				      .src_reg = 0,					\
+						 .off     = 0,					\
+							    .imm     = 0 })
+
+#define BPF_MOV64_IMM(DST, IMM)					\
+	((struct bpf_insn) {					\
+		.code    = BPF_ALU64 | BPF_MOV | BPF_K,		\
+			   .dst_reg = DST,					\
+				      .src_reg = 0,					\
+						 .off     = 0,					\
+							    .imm     = IMM })
+
+static inline __u64 ptr_to_u64(const void *ptr)
+{
+	return (__u64) (unsigned long) ptr;
+}
+
+int main(int argc, char **argv)
+{
+	struct bpf_insn insns[] = {
+		BPF_MOV64_IMM(BPF_REG_0, 0),
+		BPF_EXIT_INSN(),
+	};
+	union bpf_attr attr;
+
+	memset(&attr, 0, sizeof(attr));
+	attr.prog_type = BPF_PROG_TYPE_SOCKET_FILTER;
+	attr.insn_cnt = 2;
+	attr.insns = ptr_to_u64(insns);
+	attr.license = ptr_to_u64("GPL");
+	return syscall(__NR_bpf, BPF_PROG_LOAD, &attr, sizeof(attr)) >= 0 ? 0 : -1;
+}

--- a/tests/bpf/test
+++ b/tests/bpf/test
@@ -1,0 +1,101 @@
+#!/usr/bin/perl
+
+use strict;
+
+use Test;
+BEGIN { plan tests => 3 }
+
+use File::Temp qw/ tempfile /;
+
+my $basedir = $0;
+$basedir =~ s|(.*)/[^/]*|$1|;
+
+my $AUDIT_BPF = 1334;
+
+###
+# functions
+
+sub key_gen {
+    my @chars = ( "A" .. "Z", "a" .. "z" );
+    my $key   = "testsuite-" . time . "-";
+    $key .= $chars[ rand @chars ] for 1 .. 8;
+    return $key;
+}
+
+###
+# setup
+
+# reset audit
+system("auditctl -D >& /dev/null");
+
+# create stdout/stderr sinks
+( my $fh_out, my $stdout ) = tempfile(
+    TEMPLATE => '/tmp/audit-testsuite-out-XXXX',
+    UNLINK   => 1
+);
+( my $fh_err, my $stderr ) = tempfile(
+    TEMPLATE => '/tmp/audit-testsuite-err-XXXX',
+    UNLINK   => 1
+);
+
+###
+# tests
+
+# set the socketcall filter
+my $key = key_gen();
+
+# reset audit
+system("auditctl -D >& /dev/null");
+
+# connect
+system("auditctl -a always,exit -F arch=b64 -S bpf -k $key");
+
+# run the test
+system("$basedir/bpf");
+
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -ts recent -m $AUDIT_BPF | grep -q $key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
+
+# test if we generate any audit records from the filter rule
+my $result = system("ausearch -ts recent -m $AUDIT_BPF > $stdout 2> $stderr");
+ok( $result, 0 );
+
+my $line;
+my $found_load   = 0;
+my $found_unload = 0;
+my $ready        = 0;
+my $prog_id      = 0;
+
+while ( $line = <$fh_out> ) {
+
+    # find the first $key message and go from there
+    if ( !$ready && $line =~ /key="$key"/ ) {
+        $ready = 1;
+        next;
+    }
+
+    # find LOAD event with the $key
+    if ( $found_load == 0 && $line =~ /op=LOAD/ && $line =~ /prog-id=(\d+)/ ) {
+        $found_load = 1;
+        $prog_id    = $1;
+        next;
+    }
+
+    # find UNLOAD event with the proper $prog_id
+    if ( $line =~ /op=UNLOAD/ && $line =~ /prog-id=$prog_id/ ) {
+        $found_unload = 1;
+        last;
+    }
+}
+
+ok($found_load);
+ok($found_unload);
+
+###
+# cleanup
+
+system("auditctl -D >& /dev/null");

--- a/tests/filter_saddr_fam/test
+++ b/tests/filter_saddr_fam/test
@@ -10,7 +10,7 @@ BEGIN { plan tests => 5 }
 
 sub key_gen {
     my @chars = ( "A" .. "Z", "a" .. "z" );
-    my $key = "testsuite-" . time . "-";
+    my $key   = "testsuite-" . time . "-";
     $key .= $chars[ rand @chars ] for 1 .. 8;
     return $key;
 }


### PR DESCRIPTION
Adding test for bpf audit notification.

Kernel changes are on the way to upstream:
  https://lore.kernel.org/netdev/20191206214934.11319-1-jolsa@kernel.org/

audit-userspace changes are in here:
https://github.com/linux-audit/audit-userspace/pull/104
