### PR TITLE
BUG: tests/filter_exclude: fix MLS range parsing

### DIFF
--- a/tests/filter_exclude/test
+++ b/tests/filter_exclude/test
@@ -60,10 +60,11 @@ $result = system("id -Z >$subjout 2>/dev/null");
 ok( $result, 0 );
 my $subj = <$fh_subj>;
 chomp($subj);
-if ( $subj =~ /([^:]+):([^:]+):([^:]+):([^-]+)-([^-]+)/ ) {
+if ( $subj =~ /([^:]+):([^:]+):([^:]+):([^-]+)(?:-([^-]+))?/ ) {
     ( $subj_user, $subj_role, $subj_type, $subj_sen, $subj_clr ) =
       ( $1, $2, $3, $4, $5 );
 }
+$subj_clr = $subj_sen unless defined $subj_clr;
 
 # try adding rule for each supported field type and test for (a few)
 # unsupported types
@@ -132,7 +133,7 @@ for ( my $i = 0 ; $i < 10 ; $i++ ) {
 
 # test for the SYSCALL message provoked by creat
 $result = system(
-"ausearch -i -m SYSCALL -p $pid -ui $uid -gi $gid -ul $auid -su $subj_user:$subj_role:$subj_type:$subj_sen-$subj_clr -ts recent > $stdout 2> /dev/null"
+"ausearch -i -m SYSCALL -p $pid -ui $uid -gi $gid -ul $auid -su $subj -ts recent > $stdout 2> /dev/null"
 );
 ok( $result, 256 );
 
@@ -161,7 +162,7 @@ for ( my $i = 0 ; $i < 10 ; $i++ ) {
 
 # test for the SYSCALL message provoked by unlink
 $result = system(
-"ausearch -i -m SYSCALL -p $pid -ui $uid -gi $gid -ul $auid -su $subj_user:$subj_role:$subj_type:$subj_sen-$subj_clr -ts recent > $stdout2 2> /dev/null"
+"ausearch -i -m SYSCALL -p $pid -ui $uid -gi $gid -ul $auid -su $subj -ts recent > $stdout2 2> /dev/null"
 );
 ok( $result, 0 );
 


### PR DESCRIPTION
If the test is run under a context with identical lower and upper MLS
levels, then the context uses a simplified format with only one level
and no `-`. This confuses the filter_exclude test, which assumes the
range is always of the form `<lower>-<upper>`.

Fix the regex to treat the upper level as optional and set it to the
lower one in that case. Note that we also need to use the original $subj
string in the ausearch query, since ausearch wouldn't match the
`...:<level>-<level>` context to `...:<level>`.