### PR TITLE
RFE: test multicast join and part events without the perl socket netlink library dependancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ please follow the instructions below.
 	              perl-Test-Harness \
 	              perl-File-Which \
 	              perl-Time-HiRes \
-	              perl-Socket-Netlink \
 	              nmap-ncat
 
 ### Fedora
@@ -49,7 +48,6 @@ please follow the instructions below.
 	              perl-Test-Harness \
 	              perl-File-Which \
 	              perl-Time-HiRes \
-	              perl-Socket-Netlink \
 	              nmap-ncat
 
 ### Debian Based Systems

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ please follow the instructions below.
 	              perl-Test-Harness \
 	              perl-File-Which \
 	              perl-Time-HiRes \
+	              perl-Socket-Netlink \
 	              nmap-ncat
 
 ### Fedora
@@ -48,6 +49,7 @@ please follow the instructions below.
 	              perl-Test-Harness \
 	              perl-File-Which \
 	              perl-Time-HiRes \
+	              perl-Socket-Netlink \
 	              nmap-ncat
 
 ### Debian Based Systems

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,6 +13,7 @@ endif
 
 # all of the tests
 TESTS := \
+	amcast_joinpart \
 	backlog_wait_time_actual_reset \
 	exec_execve \
 	exec_name \

--- a/tests/amcast_joinpart/Makefile
+++ b/tests/amcast_joinpart/Makefile
@@ -1,0 +1,8 @@
+TARGETS=$(patsubst %.c,%,$(wildcard *.c))
+
+LDLIBS += -lpthread
+
+all: $(TARGETS)
+
+clean:
+	rm -f $(TARGETS)

--- a/tests/amcast_joinpart/test
+++ b/tests/amcast_joinpart/test
@@ -1,0 +1,119 @@
+#!/usr/bin/perl
+
+use strict;
+
+use Test;
+BEGIN { plan tests => 7 }
+
+use File::Temp qw/ tempfile /;
+use Socket;
+use Socket::Netlink qw( :DEFAULT pack_sockaddr_nl );
+
+my $basedir = $0;
+$basedir =~ s|(.*)/[^/]*|$1|;
+
+###
+# functions
+
+sub key_gen {
+    my @chars = ( "A" .. "Z", "a" .. "z" );
+    my $key   = "testsuite-" . time . "-";
+    $key .= $chars[ rand @chars ] for 1 .. 8;
+    return $key;
+}
+
+###
+# setup
+
+# reset audit
+system("auditctl -D >& /dev/null");
+
+# create stdout/stderr sinks
+( my $fh_out, my $stdout ) = tempfile(
+    TEMPLATE => '/tmp/audit-testsuite-out-XXXX',
+    UNLINK   => 1
+);
+( my $fh_err, my $stderr ) = tempfile(
+    TEMPLATE => '/tmp/audit-testsuite-err-XXXX',
+    UNLINK   => 1
+);
+( my $fh_out2, my $stdout2 ) = tempfile(
+    TEMPLATE => '/tmp/audit-testsuite-out-XXXX',
+    UNLINK   => 1
+);
+( my $fh_err2, my $stderr2 ) = tempfile(
+    TEMPLATE => '/tmp/audit-testsuite-err-XXXX',
+    UNLINK   => 1
+);
+
+###
+# tests
+
+# limit ausearch to this test's events
+my ( $sec, $min, $hour, $mday, $mon, $year, $wday, $yday, $isdst ) =
+  localtime(time);
+$year += 1900;
+$mon  += 1;
+my $startdatetime = sprintf "%04d-%02d-%02d %02d:%02d:%02d", $year, $mon,
+  $mday, $hour, $min, $sec;
+
+# set the filter
+my $key = key_gen();
+my $result;
+
+# issue command to generate EVENT_LISTENER event
+my $sock;
+$result = socket( $sock, AF_NETLINK, SOCK_RAW, 9 );    # NETLINK_AUDIT
+ok($result);                                           # socket call succeeded?
+$result = bind( $sock, pack_sockaddr_nl( 0, 1 ) );
+ok($result);                                           # bind succeeded?
+$result = setsockopt( $sock, 270, 2, 1 )
+  ;    # SOL_NETLINK, NETLINK_DROP_MEMBERSHIP, AUDIT_NLGRP_READLOG
+ok($result);    # drop succeeded?
+close($sock);
+
+# create marker event and wait for it to ensure our events are in the log
+system("auditctl -m syncmarker-$key >/dev/null 2>&1");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
+
+# test if we generate any audit records from the filter rule
+$result = system(
+"LC_TIME=en_DK.utf8 ausearch -i -m 1335 -ts $startdatetime > $stdout 2> $stderr"
+);
+ok( $result, 0 );    # found records filtered on record type?
+
+# test if we generate the EVENT_LISTENER record
+my $line;
+my $line2;
+my $type;
+my $id                              = "";
+my $found_event_listener            = 0;
+my $found_event_listener_connect    = 0;
+my $found_event_listener_disconnect = 0;
+
+while ( $line = <$fh_out> ) {
+    if ( $line =~ /^type=(EVENT_LISTENER|UNKNOWN\[1335\]) / ) {
+        if ( $line =~ / nl-mcgrp=1 op=((dis|)connect) res=(yes|no)/ ) {
+            $found_event_listener = 1;
+            if ( $1 eq "connect" ) {
+                $found_event_listener_connect = 1;
+            }
+            if ( $1 eq "disconnect" ) {
+                $found_event_listener_disconnect = 1;
+            }
+        }
+    }
+}
+ok($found_event_listener);               # Found event_listener event?
+ok($found_event_listener_connect);       # Found connect event?
+ok($found_event_listener_disconnect);    # Found disconnect event?
+
+###
+# cleanup
+
+system("auditctl -D >& /dev/null");

--- a/tests/amcast_joinpart/test
+++ b/tests/amcast_joinpart/test
@@ -7,7 +7,8 @@ BEGIN { plan tests => 7 }
 
 use File::Temp qw/ tempfile /;
 use Socket;
-use Socket::Netlink qw( :DEFAULT pack_sockaddr_nl );
+
+#use Socket::Netlink qw( :DEFAULT pack_sockaddr_nl );
 
 my $basedir = $0;
 $basedir =~ s|(.*)/[^/]*|$1|;
@@ -63,12 +64,26 @@ my $result;
 
 # issue command to generate EVENT_LISTENER event
 my $sock;
-$result = socket( $sock, AF_NETLINK, SOCK_RAW, 9 );    # NETLINK_AUDIT
-ok($result);                                           # socket call succeeded?
-$result = bind( $sock, pack_sockaddr_nl( 0, 1 ) );
-ok($result);                                           # bind succeeded?
-$result = setsockopt( $sock, 270, 2, 1 )
-  ;    # SOL_NETLINK, NETLINK_DROP_MEMBERSHIP, AUDIT_NLGRP_READLOG
+my $AF_NETLINK              = 16;
+my $NETLINK_AUDIT           = 9;
+my $AUDIT_NLGRP_READLOG     = 1;
+my $SOL_NETLINK             = 270;
+my $NETLINK_DROP_MEMBERSHIP = 2;
+$result = socket( $sock, $AF_NETLINK, SOCK_RAW, $NETLINK_AUDIT );
+ok($result);    # socket call succeeded?
+
+#$result = bind( $sock, pack_sockaddr_nl( 0, $AUDIT_NLGRP_READLOG ) );
+;    #my( $hex ) = unpack( 'H*', pack_sockaddr_nl(0,$AUDIT_NLGRP_READLOG) );
+;    #print "pack_sockaddr_nl=$hex\n";
+;    # from include/uapi/linux/netlink.h:struct sockaddr_nl
+; # nl_family(u16):AF_NETLINK, nl_pad(u16):0, nl_pid(u32):0, nl_groups(u32):AUDIT_NLGRP_READLOG
+my $snl = pack( "SSLL", $AF_NETLINK, 0, 0, $AUDIT_NLGRP_READLOG );
+;    #my( $hex2 ) = unpack( 'H*', $snl );
+;    #print "             snl=$hex2\n";
+$result = bind( $sock, $snl );
+ok($result);    # bind succeeded?
+$result = setsockopt( $sock, $SOL_NETLINK, $NETLINK_DROP_MEMBERSHIP,
+    $AUDIT_NLGRP_READLOG );
 ok($result);    # drop succeeded?
 close($sock);
 


### PR DESCRIPTION
I'd prefer to keep both patches rather than squash them down and delete the commented out code, to show how the open code was derived and how to test/fix it in the future if it breaks.