### PR TITLE
tests: add openat2 to open(2) activity

### DIFF
--- a/tests/file_create/test
+++ b/tests/file_create/test
@@ -87,7 +87,7 @@ while ( $line = <$fh_out> ) {
 
     # test if we generate a SYSCALL record
     if ( $line =~ /^type=SYSCALL / ) {
-        if ( ( $line =~ / syscall=open / or $line =~ / syscall=openat / )
+        if ( ( $line =~ / syscall=open(at|at2)? / )
             and $line =~ / success=yes / )
         {
             $found_syscall = 1;

--- a/tests/syscalls_file/Makefile
+++ b/tests/syscalls_file/Makefile
@@ -3,6 +3,10 @@ TARGETS=$(patsubst %.c,%,$(wildcard *.c))
 LDLIBS += -lpthread
 
 all: $(TARGETS)
+
+openat2: openat2.c
+	$(CC) $(CFLAGS) -o $@ $^
+
 clean:
 	rm -f $(TARGETS)
 

--- a/tests/syscalls_file/openat2.c
+++ b/tests/syscalls_file/openat2.c
@@ -1,0 +1,76 @@
+/*
+ * audit-testsuite OPENAT2 test tool
+ *
+ * Copyright (c) 2021 Red Hat <rgb@redhat.com>
+ * Author: Richard Guy Briggs <rgb@tricolour.ca>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+/* not available yet on travis-ci.org
+ * #include <linux/openat2.h>
+ */
+struct open_how {
+	long long unsigned flags;
+	long long unsigned mode;
+	long long unsigned resolve;
+};
+#define RESOLVE_NO_MAGICLINKS	0x02
+#define RESOLVE_BENEATH		0x08
+
+#include <sys/syscall.h>
+
+int main(int argc, char **argv)
+{
+	char *test_dir = argv[1] ? : ".";
+	int dir_fd, file_fd;
+	char *file_name = argv[2] ? : "file-openat2";
+	struct open_how how = { .flags = O_CREAT | O_RDWR | O_EXCL,
+		       .mode = 0600,
+		       .resolve = RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS,
+	};
+
+	dir_fd = open(test_dir, O_RDONLY | O_DIRECTORY);
+	if (dir_fd == -1) {
+		printf("cannot open directory %s\n", test_dir);
+		return 1;
+	}
+
+	/* Try to create a file.  */
+	printf("create file=%s in directory=%s with flags=0%llo, mode=0%llo, resolve=0x%0llx\n",
+	       file_name, test_dir, how.flags, how.mode, how.resolve);
+	file_fd = syscall(437, dir_fd, file_name, &how, sizeof(how)); //__NR_openat2
+	if (file_fd == -1) {
+		if (errno == ENOSYS) {
+			printf("openat2 function not supported\n");
+			return 2;
+		}
+		printf("file creation failed\n");
+		return 1;
+	}
+	close(file_fd);
+	close(dir_fd);
+	return 0;
+}

--- a/tests/syscalls_file/test
+++ b/tests/syscalls_file/test
@@ -7,6 +7,9 @@ BEGIN { plan tests => 3 }
 
 use File::Temp qw/ tempdir tempfile /;
 
+my $basedir = $0;
+$basedir =~ s|(.*)/[^/]*|$1|;
+
 ###
 # functions
 
@@ -42,17 +45,24 @@ my $dir = tempdir( TEMPLATE => '/tmp/audit-testsuite-XXXX', CLEANUP => 1 );
 # tests
 
 # audit all open() syscalls on 64-bit systems
-my $key         = key_gen();
+my $key = key_gen();
+my $result;
 my $result_open = system(
     "auditctl -a always,exit -F arch=b$abi_bits -S open -k $key 2> $stderr");
 my $result_openat =
   system("auditctl -a always,exit -F arch=b$abi_bits -S openat -k $key");
-
-ok( $result_open == 0 or $result_openat == 0 );
+my $result_openat2 =
+  system("auditctl -a always,exit -F arch=b$abi_bits -S 437 -k $key");  #openat2
+ok( $result_open == 0 or $result_openat == 0 or $result_openat2 == 0 );
 
 # create a new file
 ( my $fh, my $filename ) =
   tempfile( TEMPLATE => $dir . "/file-XXXX", UNLINK => 1 );
+
+system("$basedir/openat2 $dir file-openat2");
+if ( defined $ENV{ATS_DEBUG} && $ENV{ATS_DEBUG} == 1 ) {
+    system("echo Contents of $dir:;ls -ltr $dir");
+}
 
 # make sure the records had a chance to bubble through to the logs
 system("auditctl -m sync-$key");
@@ -64,7 +74,7 @@ for ( my $i = 0 ; $i < 10 ; $i++ ) {
 }
 
 # test if we generate any audit records
-my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
+$result = system("ausearch -i -k $key > $stdout 2> $stderr");
 ok( $result, 0 );
 
 # test if we generate the SYSCALL record correctly
@@ -73,10 +83,8 @@ my $found_syscall = 0;
 my $found_parent  = 0;
 my $found_create  = 0;
 while ( $line = <$fh_out> ) {
-
-    # test if we generate a SYSCALL record
     if ( $line =~ /^type=SYSCALL /
-        and ( $line =~ / syscall=open(at)? / ) )
+        and ( $line =~ / syscall=open(at|at2)? / ) )
     {
         $found_syscall = 1;
     }


### PR DESCRIPTION
openat2(2) was added to kernel v5.6.  Add support for it to tests that care
about open(2) and family.

Signed-off-by: Richard Guy Briggs <rgb@redhat.com>