### PR TITLE
BUG: adjust ptrace timing in tests/signal

### DIFF
--- a/tests/signal/test
+++ b/tests/signal/test
@@ -85,9 +85,10 @@ ok( $result, 0 );    # Was the rule accepted?
 
 # Create task to which to attach
 seek( $fh_out, 0, 0 );
-system("sleep .1 >/dev/null 2>&1 & echo \$! >$stdout");
+system("sleep 1 >/dev/null 2>&1 & echo \$! >$stdout");
 my $task2_pid = <$fh_out>;
 chomp($task2_pid);
+sleep .5;
 
 # Generate a ptrace event
 $result = system("strace -p $task2_pid >/dev/null 2>&1");


### PR DESCRIPTION
The ptrace call sometimes missed the task to which it was attempting to attach.

  Test 5 got: "256" (signal/test at line 94)
    Expected: "0"
   signal/test line 94 is: ok( $result, 0 );    # Was the ptrace command successful?
  Test 8 got: "0" (signal/test at line 136)
    Expected: "1"
   signal/test line 136 is: ok( $found_ptrace, 1 );    # Was the ptrace found?

  signal/test (Wstat: 0 Tests: 8 Failed: 2)
    Failed tests:  5, 8

Provide a bit larger time window to allow it to attach.

Fixes: 1e2c58c5c2e0 ("tests: add test for signal and ptrace OBJ_PID records")
Signed-off-by: Richard Guy Briggs <rgb@redhat.com>