### PR TITLE
RFE: add file_permission test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,6 +20,7 @@ TESTS := \
 	fanotify \
 	file_create \
 	file_delete \
+	file_permission \
 	file_rename \
 	filter_exclude \
 	filter_saddr_fam \

--- a/tests/file_permission/Makefile
+++ b/tests/file_permission/Makefile
@@ -1,0 +1,8 @@
+TARGETS=$(patsubst %.c,%,$(wildcard *.c))
+
+LDLIBS += -lpthread
+
+all: $(TARGETS)
+clean:
+	rm -f $(TARGETS)
+

--- a/tests/file_permission/test
+++ b/tests/file_permission/test
@@ -1,0 +1,118 @@
+#!/usr/bin/perl
+
+use strict;
+
+use Test;
+BEGIN { plan tests => 3 }
+
+use File::Temp qw/ tempdir tempfile /;
+
+###
+# functions
+
+sub key_gen {
+    my @chars = ( "A" .. "Z", "a" .. "z" );
+    my $key   = "testsuite-" . time . "-";
+    $key .= $chars[ rand @chars ] for 1 .. 8;
+    return $key;
+}
+
+###
+# setup
+
+# reset audit
+system("auditctl -D >& /dev/null");
+
+# create temp directory
+my $dir = tempdir( TEMPLATE => '/tmp/audit-testsuite-XXXX', CLEANUP => 1 );
+
+# create stdout/stderr sinks
+( my $fh_out, my $stdout ) = tempfile(
+    TEMPLATE => '/tmp/audit-testsuite-out-XXXX',
+    UNLINK   => 1
+);
+( my $fh_err, my $stderr ) = tempfile(
+    TEMPLATE => '/tmp/audit-testsuite-err-XXXX',
+    UNLINK   => 1
+);
+
+###
+# tests
+
+# set the directory watch
+my $key = key_gen();
+system("auditctl -a always,exit -F dir=$dir -k $key");
+
+# create a new file in the watched directory
+( my $fh, my $filename ) =
+  tempfile( TEMPLATE => $dir . "/file-XXXX", UNLINK => 1 );
+(
+    my $dev,
+    my $ino,
+    my $mode,
+    my $nlink,
+    my $uid,
+    my $gid,
+    my $rdev,
+    my $size,
+    my $atime,
+    my $mtime,
+    my $ctime,
+    my $blksize,
+    my $blocks
+) = stat($filename);
+my $dev_fmt = sprintf( "%02x:%02x", $dev >> 8, $dev & 0x00ff );
+my $uid_fmt = getpwuid($uid);
+my $gid_fmt = getgrgid($uid);
+
+# change the file permissions
+chmod( 0775, $filename );
+
+# make sure the records had a chance to bubble through to the logs
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
+
+# test if we generate any audit records from the watch
+my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
+ok( $result, 0 );
+
+# test if we generate the SYSCALL and PATH(NORMAL) records correctly
+my $line;
+my $found_syscall = 0;
+my $found_normal  = 0;
+while ( $line = <$fh_out> ) {
+
+    # test if we generate a SYSCALL record
+    if ( $line =~ /^type=SYSCALL / ) {
+        if ( ( $line =~ / syscall=(f)?chmod(at|at2)? / )
+            and $line =~ / success=yes / )
+        {
+            $found_syscall = 1;
+        }
+    }
+    if ( $line =~ /^type=PATH / ) {
+
+        # test if we generate a PATH(nametype=NORMAL) record
+        if (    $line =~ / name=$filename /
+            and $line =~ / dev=$dev_fmt /
+            and $line =~ / inode=$ino /
+            and $line =~ / ouid=$uid_fmt /
+            and $line =~ / ogid=$gid_fmt /
+            and $line =~ / (nametype|objtype)=NORMAL / )
+        {
+            $found_normal = 1;
+        }
+    }
+}
+ok($found_syscall);
+ok($found_normal);
+
+###
+# cleanup
+
+system("auditctl -D >& /dev/null");


### PR DESCRIPTION
Add a very basic file permission change event filtering tests using the perl Test::Simple framework and with the file_delete test as inspiration.

See: https://github.com/linux-audit/audit-testsuite/issues/12

Signed-off-by: Ricardo Robaina <rrobaina@redhat.com>