### PR TITLE
BUG: syscalls_file fixes

### DIFF
--- a/tests/syscalls_file/test
+++ b/tests/syscalls_file/test
@@ -50,11 +50,15 @@ my $nr_openat2 = 437;
 my $key = key_gen();
 my $result;
 my $result_open = system(
-    "auditctl -a always,exit -F arch=b$abi_bits -S open -k $key 2> $stderr");
+"auditctl -a always,exit -F arch=b$abi_bits -F dir=$dir -S open -k $key 2> $stderr"
+);
 my $result_openat =
-  system("auditctl -a always,exit -F arch=b$abi_bits -S openat -k $key");
+  system(
+    "auditctl -a always,exit -F arch=b$abi_bits -F dir=$dir -S openat -k $key");
 my $result_openat2 =
-  system("auditctl -a always,exit -F arch=b$abi_bits -S $nr_openat2 -k $key");
+  system(
+"auditctl -a always,exit -F arch=b$abi_bits -F dir=$dir -S $nr_openat2 -k $key"
+  );
 ok( $result_open == 0 or $result_openat == 0 or $result_openat2 == 0 );
 
 # create a new file

--- a/tests/syscalls_file/test
+++ b/tests/syscalls_file/test
@@ -67,9 +67,11 @@ if ( defined $ENV{ATS_DEBUG} && $ENV{ATS_DEBUG} == 1 ) {
 }
 
 # make sure the records had a chance to bubble through to the logs
-system("auditctl -m sync-$key");
+system("auditctl -m syncmarker-$key");
 for ( my $i = 0 ; $i < 10 ; $i++ ) {
-    if ( system("ausearch -m USER 2> /dev/null | grep -q sync-$key") eq 0 ) {
+    if (
+        system("ausearch -m USER 2> /dev/null | grep -q syncmarker-$key") eq 0 )
+    {
         last;
     }
     sleep(0.2);


### PR DESCRIPTION
A couple of fixes for the syscalls_file test:
- Rename the user message label for consistency "syncmarker"
- Restrict the open* syscall monitoring to the test directory to avoid oom failures