### PR TITLE
filter_exclude: remove auid check from unlink SYSCALL mesage check

### DIFF
--- a/tests/filter_exclude/test
+++ b/tests/filter_exclude/test
@@ -162,7 +162,7 @@ for ( my $i = 0 ; $i < 10 ; $i++ ) {
 
 # test for the SYSCALL message provoked by unlink
 $result = system(
-"ausearch -i -m SYSCALL -p $pid -ui $uid -gi $gid -ul $auid -su $subj -ts recent > $stdout2 2> /dev/null"
+"ausearch -i -m SYSCALL -p $pid -ui $uid -gi $gid -su $subj -ts recent > $stdout2 2> /dev/null"
 );
 ok( $result, 0 );
 


### PR DESCRIPTION
The test filter_exclude fails on cases 20 and 21 if you log on the test machine using a non-root user and then switch to root. Removing auid check to avoid this failure, since the auid check is not required in the context of these test cases.

See: https://github.com/linux-audit/audit-testsuite/issues/113

Signed-off-by: Ricardo Robaina <rrobaina@redhat.com>