### PR TITLE
RFE: add field_compare test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,6 +19,7 @@ TESTS := \
 	exec_execve \
 	exec_name \
 	fanotify \
+	field_compare \
 	file_create \
 	file_delete \
 	file_permission \

--- a/tests/field_compare/Makefile
+++ b/tests/field_compare/Makefile
@@ -1,0 +1,8 @@
+TARGETS=$(patsubst %.c,%,$(wildcard *.c))
+
+LDLIBS += -lpthread
+
+all: $(TARGETS)
+clean:
+	rm -f $(TARGETS)
+

--- a/tests/field_compare/test
+++ b/tests/field_compare/test
@@ -1,0 +1,107 @@
+#!/usr/bin/perl
+
+use strict;
+
+use Test;
+BEGIN { plan tests => 50 }
+
+use File::Temp qw/ tempdir tempfile /;
+
+###
+# functions
+
+sub key_gen {
+    my @chars = ( "A" .. "Z", "a" .. "z" );
+    my $key   = "testsuite-" . time . "-";
+    $key .= $chars[ rand @chars ] for 1 .. 8;
+    return $key;
+}
+
+###
+# setup
+
+# reset audit
+system("auditctl -D >& /dev/null");
+
+# create temp directory
+my $dir = tempdir( TEMPLATE => '/tmp/audit-testsuite-XXXX', CLEANUP => 1 );
+
+# create stdout/stderr sinks
+( my $fh_out, my $stdout ) = tempfile(
+    TEMPLATE => '/tmp/audit-testsuite-out-XXXX',
+    UNLINK   => 1
+);
+( my $fh_err, my $stderr ) = tempfile(
+    TEMPLATE => '/tmp/audit-testsuite-err-XXXX',
+    UNLINK   => 1
+);
+
+###
+# tests
+
+# uid fields tests
+my @fields = ( "auid", "uid", "euid", "suid", "fsuid", "obj_uid" );
+
+# equal operator
+for my $i ( 0 .. $#fields ) {
+    for ( my $j = $i + 1 ; $j <= $#fields ; $j++ ) {
+        my $key = key_gen();
+        system(
+"auditctl -a always,exit -S openat -C $fields[$i]=$fields[$j] -k $key > $stdout 2> $stderr"
+        );
+        my $filename = tempfile( TEMPLATE => $dir . "/file-XXXX", UNLINK => 1 );
+        unlink($filename);
+        my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
+        ok( $result, 0 );
+        system("auditctl -D >& /dev/null");
+    }
+}
+
+# not equal opeator
+for my $i ( 0 .. $#fields ) {
+    for ( my $j = $i + 1 ; $j <= $#fields ; $j++ ) {
+        my $key = key_gen();
+        system(
+"auditctl -a always,exit -S openat -C $fields[$i]!=$fields[$j] -k $key > $stdout 2> $stderr"
+        );
+        my $filename = tempfile( TEMPLATE => $dir . "/file-XXXX", UNLINK => 1 );
+        unlink($filename);
+        my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
+        ok( $result, 0 );
+        system("auditctl -D >& /dev/null");
+    }
+}
+
+# gid field tests
+@fields = ( "gid", "egid", "sgid", "fsgid", "obj_gid" );
+
+# equal tests
+for my $i ( 0 .. $#fields ) {
+    for ( my $j = $i + 1 ; $j <= $#fields ; $j++ ) {
+        my $key = key_gen();
+        system(
+"auditctl -a always,exit -S openat -C $fields[$i]=$fields[$j] -k $key > $stdout 2> $stderr"
+        );
+        my $filename = tempfile( TEMPLATE => $dir . "/file-XXXX", UNLINK => 1 );
+        unlink($filename);
+        my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
+        ok( $result, 0 );
+        system("auditctl -D >& /dev/null");
+    }
+}
+
+# not equal tests
+for my $i ( 0 .. $#fields ) {
+    for ( my $j = $i + 1 ; $j <= $#fields ; $j++ ) {
+        my $key = key_gen();
+        system(
+"auditctl -a always,exit -S openat -C $fields[$i]!=$fields[$j] -k $key > $stdout 2> $stderr"
+        );
+        my $filename = tempfile( TEMPLATE => $dir . "/file-XXXX", UNLINK => 1 );
+        unlink($filename);
+        my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
+        ok( $result, 0 );
+        system("auditctl -D >& /dev/null");
+    }
+}
+


### PR DESCRIPTION
Issue: https://github.com/linux-audit/audit-testsuite/issues/5

Simple test case to test UID/GID event filtering.

This test case adds full coverage to the following auditsc.c functions, which are not exercised by any other test case of the test suite:
 - audit_field_compare()
 - audit_compare_gid()
 - audit_compare_uid()
 
Signed-off-by: Ricardo Robaina <rrobaina@redhat.com>
