### PR TITLE
tests/filter_device: add device major/minor filter test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -23,6 +23,7 @@ TESTS := \
 	file_delete \
 	file_permission \
 	file_rename \
+	filter_device \
 	filter_exclude \
 	filter_exit \
 	filter_saddr_fam \

--- a/tests/filter_device/Makefile
+++ b/tests/filter_device/Makefile
@@ -1,0 +1,8 @@
+TARGETS=$(patsubst %.c,%,$(wildcard *.c))
+
+LDLIBS += -lpthread
+
+all: $(TARGETS)
+clean:
+	rm -f $(TARGETS)
+

--- a/tests/filter_device/test
+++ b/tests/filter_device/test
@@ -1,0 +1,123 @@
+#!/usr/bin/perl
+
+use strict;
+
+use Test;
+BEGIN { plan tests => 15 }
+
+use File::Temp qw/ tempfile /;
+
+###
+# functions
+
+sub key_gen {
+    my @chars = ( "A" .. "Z", "a" .. "z" );
+    my $key   = "testsuite-" . time . "-";
+    $key .= $chars[ rand @chars ] for 1 .. 8;
+    return $key;
+}
+
+###
+# setup
+
+# reset audit
+system("auditctl -D >& /dev/null");
+
+# create stdout/stderr sinks
+( my $fh_out, my $stdout ) = tempfile(
+    TEMPLATE => '/tmp/audit-testsuite-out-XXXX',
+    UNLINK   => 1
+);
+( my $fh_err, my $stderr ) = tempfile(
+    TEMPLATE => '/tmp/audit-testsuite-err-XXXX',
+    UNLINK   => 1
+);
+
+###
+# tests
+
+# create a key
+my $key = key_gen();
+
+# create test cases
+#       ["dev name", dev major, dev minor]
+my @tests = (
+    [ "/dev/$key-loop-all", 9, 6 ],
+    [ "/dev/$key-loop-maj", 8, 0 ],
+    [ "/dev/$key-loop-min", 0, 5 ]
+);
+
+# create rules
+system(
+"auditctl -a always,exit -S all -F devmajor=$tests[0][1] -F devminor=$tests[0][2] -k $key"
+);
+system("auditctl -a always,exit -S all -F devmajor=$tests[1][1] -k $key");
+system("auditctl -a always,exit -S all -F devminor=$tests[2][2] -k $key");
+
+# create block devices for each test case
+for ( my $i = 0 ; $i < scalar @tests ; $i++ ) {
+    system("mknod $tests[$i][0] b $tests[$i][1] $tests[$i][2]");
+}
+
+# make sure the records had a chance to bubble through to the logs
+system("auditctl -m syncmarker-$key");
+for ( my $i = 0 ; $i < 10 ; $i++ ) {
+    if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+        last;
+    }
+    sleep(0.2);
+}
+
+# check the results
+system("ausearch -i -k $key > $stdout 2> $stderr");
+
+my $line;
+my $found_path;
+my $name_match;
+my $dev_match;
+my $found_syscall;
+my $syscall_match;
+for ( my $i = 0 ; $i < scalar @tests ; $i++ ) {
+    $found_path    = 0;
+    $name_match    = 0;
+    $dev_match     = 0;
+    $found_syscall = 0;
+    $syscall_match = 0;
+
+    while ( $line = <$fh_out> ) {
+
+        # test if PATH record matches
+        if ( $line =~ /^type=PATH / ) {
+            $found_path = 1;
+
+            if ( $line =~ / name=$tests[$i][0] / ) {
+                $name_match = 1;
+            }
+
+            if ( $line =~ / rdev=0$tests[$i][1]:0$tests[$i][2] / ) {
+                $dev_match = 1;
+            }
+        }
+
+        # test if SYSCALL record matches
+        if ( $line =~ /^type=SYSCALL / ) {
+            $found_syscall = 1;
+
+            if ( $line =~ / syscall=mknodat / ) {
+                $syscall_match = 1;
+            }
+        }
+    }
+    ok($found_path);
+    ok($name_match);
+    ok($dev_match);
+    ok($found_syscall);
+    ok($syscall_match);
+    seek $fh_out, 0, 0;
+}
+
+###
+# cleanup
+system("rm /dev/$key*");
+
+system("auditctl -D >& /dev/null");


### PR DESCRIPTION
This patch introduces a straightforward test case for filtering devices based on their major and minor numbers. It includes three distinct test scenarios: one for filtering by major number, another for minor number, and a third combining both major and minor filters.

See: https://github.com/linux-audit/audit-testsuite/issues/7

Signed-off-by: Ricardo Robaina <rrobaina@redhat.com>