### PR TITLE
BUG: add strace package as a RHEL/CentOS and Fedora dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ please follow the instructions below.
 	              perl-Socket-Netlink \
 	              nmap-ncat \
 	              psmisc \
-	              liburing-devel
+	              liburing-devel \
+	              strace
 
 ### Fedora
 
@@ -54,7 +55,8 @@ please follow the instructions below.
 	              perl-Socket-Netlink \
 	              nmap-ncat \
 	              psmisc \
-	              liburing-devel
+	              liburing-devel \
+	              strace
 
 ### Debian Based Systems
 


### PR DESCRIPTION
The strace tool is invoked in the signal test, as shown in the code snippet below.

signal/test:
...
 98 # Generate a ptrace event
 99 $result = system("strace -p $task2_pid >/dev/null 2>&1");
100 ok( $result, 0 );    # Was the ptrace command successful?
...

However,  the strace package is not installed by default in recent RHEL/CentOS and Fedora distros. This missing dependency results in a signal test failure below:

signal/test .. 2/8 # Test 5 got: "32512" (signal/test at line 100)

  Expected: "0"  signal/test line 100 is: ok( $result, 0 );    # Was the ptrace
  command successful? Test 8 got: "0" (signal/test at line 142)   Expected: "1"
  signal/test line 142 is: ok( $found_ptrace, 1 );    # Was the ptrace found?

signal/test .. Failed 2/8 subtests

This commit adds the strace package in both RHEL/CentOS and Fedora dependency lists in order to avoid this issue in the future.

Signed-off-by: Ricardo Robaina <rrobaina@redhat.com>