### PR TITLE
RFE: test kernel module loading using a module that is present by default

### DIFF
--- a/tests/syscall_module/test
+++ b/tests/syscall_module/test
@@ -51,7 +51,8 @@ system(
 );
 
 # run the test
-my $name = "arp_tables";
+# Can be any kernel module that isn't loaded by default
+my $name = "sg";
 $result = system("modprobe $name >/dev/null 2>&1");
 ok( $result, 0 );    # Did the modprobe succeed?
 


### PR DESCRIPTION
Since 6.13, the arp_tables module is not available in the default kernel config anymore, so let's use a different module, because the test doesn't need any specific one.

Tested in Nix by adjusting https://github.com/NixOS/nixpkgs/pull/465550