### PR TITLE
BUG: fix race conditions in tests/field_compare

### DIFF
--- a/tests/field_compare/test
+++ b/tests/field_compare/test
@@ -51,6 +51,16 @@ for my $i ( 0 .. $#fields ) {
         );
         my $filename = tempfile( TEMPLATE => $dir . "/file-XXXX", UNLINK => 1 );
         unlink($filename);
+
+        # make sure the records had a chance to bubble through to the logs
+        system("auditctl -m syncmarker-$key");
+        for ( my $i = 0 ; $i < 10 ; $i++ ) {
+            if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+                last;
+            }
+            sleep(0.2);
+        }
+
         my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
         ok( $result, 0 );
         system("auditctl -D >& /dev/null");
@@ -66,6 +76,16 @@ for my $i ( 0 .. $#fields ) {
         );
         my $filename = tempfile( TEMPLATE => $dir . "/file-XXXX", UNLINK => 1 );
         unlink($filename);
+
+        # make sure the records had a chance to bubble through to the logs
+        system("auditctl -m syncmarker-$key");
+        for ( my $i = 0 ; $i < 10 ; $i++ ) {
+            if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+                last;
+            }
+            sleep(0.2);
+        }
+
         my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
         ok( $result, 0 );
         system("auditctl -D >& /dev/null");
@@ -84,6 +104,16 @@ for my $i ( 0 .. $#fields ) {
         );
         my $filename = tempfile( TEMPLATE => $dir . "/file-XXXX", UNLINK => 1 );
         unlink($filename);
+
+        # make sure the records had a chance to bubble through to the logs
+        system("auditctl -m syncmarker-$key");
+        for ( my $i = 0 ; $i < 10 ; $i++ ) {
+            if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+                last;
+            }
+            sleep(0.2);
+        }
+
         my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
         ok( $result, 0 );
         system("auditctl -D >& /dev/null");
@@ -99,6 +129,16 @@ for my $i ( 0 .. $#fields ) {
         );
         my $filename = tempfile( TEMPLATE => $dir . "/file-XXXX", UNLINK => 1 );
         unlink($filename);
+
+        # make sure the records had a chance to bubble through to the logs
+        system("auditctl -m syncmarker-$key");
+        for ( my $i = 0 ; $i < 10 ; $i++ ) {
+            if ( system("ausearch -m USER | grep -q syncmarker-$key") eq 0 ) {
+                last;
+            }
+            sleep(0.2);
+        }
+
         my $result = system("ausearch -i -k $key > $stdout 2> $stderr");
         ok( $result, 0 );
         system("auditctl -D >& /dev/null");


### PR DESCRIPTION
On busy machines, false positive test failures occasionally occur due to a lack of synchronization between triggering and checking audit events.

This commit adds synchronization points between event triggering and checking to eliminate these race conditions and stabilize the tests.

Signed-off-by: Ricardo Robaina <rrobaina@redhat.com>